### PR TITLE
add dynamic image creation code & json refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Configure with [config.js](config.js).
 
 The `names-<version>.json` files are based on JSON files created by OpenWrt (master): `Global build settings  ---> [*] Create JSON info files per build image`.
 
-A [Python script](misc/collect.py) is included to create those json files: `./collect.py bin/ --link 'https://downloads.openwrt.org/releases/%release/targets/%target/%file' > names-test.json`.
+A [Python script](misc/collect.py) is included to create those json files: `./collect.py bin/ --url 'https://downloads.openwrt.org/releases/{release}/targets/{target}' > names-test.json`.
 
 Note: Files `names-18.06.7.json` and `names-19.07.1.json` contain data for older OpenWrt releases that do not support JSON output. It was generated using heuristics.
 

--- a/config.js
+++ b/config.js
@@ -6,8 +6,8 @@ var config = {
   showHelp: true,
   // Files to get data from
   versions: {
-    'SNAPSHOT': 'names-SNAPSHOT.json',
-    '19.07.1': 'names-19.07.1.json',
-    '18.06.7': 'names-18.06.7.json'
-  }
+//    'SNAPSHOT': '/api/names/SNAPSHOT' // when using asu backend
+    'SNAPSHOT': 'names-SNAPSHOT.json'
+  },
+  asu_url: '/api/build'
 };

--- a/misc/collect.py
+++ b/misc/collect.py
@@ -8,9 +8,9 @@ import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument("input_path", nargs='?', help="Input folder that is traversed for OpenWrt JSON device files.")
-parser.add_argument('--link',
-            action="store", dest="link", default="",
-            help="Link to get the image from. May contain %%file, %%target, %%release and %%commit")
+parser.add_argument('--url',
+            action="store", dest="url", default="",
+            help="Link to get the image from. May contain {target}, {release} and {commit}")
 parser.add_argument('--formatted',
             action="store_true", dest="formatted", help="Output formatted JSON data.")
 
@@ -44,21 +44,21 @@ for path in paths:
       version = obj['version_number']
       commit = obj['version_commit']
 
-      if not 'commit' in output:
+      if not 'version_commit' in output:
         output = {
-          'commit': commit,
-          'link': args.link,
+          'version_commit': commit,
+          'url': args.url,
           'models' : {}
         }
 
       # only support a version_number with images of a single version_commit
-      if output['commit'] != commit:
-        sys.stderr.write('mixed revisions for a release ({} and {}) => abort\n'.format(output['commit'], commit))
+      if output['version_commit'] != commit:
+        sys.stderr.write('mixed revisions for a release ({} and {}) => abort\n'.format(output['version_commit'], commit))
         exit(1)
 
       images = []
       for image in obj['images']:
-          images.append(image['name'])
+          images.append({"name": image['name']})
 
       target = obj['target']
       id = obj['id']
@@ -78,6 +78,6 @@ for path in paths:
       exit(1)
 
 if args.formatted:
-  json.dump(output, sys.stdout, indent="  ")
+  json.dump(output, sys.stdout, indent="  ", sort_keys =  True)
 else:
-  json.dump(output, sys.stdout)
+  json.dump(output, sys.stdout, sort_keys = True)

--- a/names-SNAPSHOT.json
+++ b/names-SNAPSHOT.json
@@ -1,7592 +1,10608 @@
 {
-  "commit": "r12145-4716c843d6",
-  "link": "https://downloads.openwrt.org/snapshots/targets/%target/%file",
   "models": {
-    "SolidRun MACCHIATObin": {
-      "id": "marvell_macchiatobin",
-      "target": "mvebu/cortexa72",
-      "images": [
-        "openwrt-mvebu-cortexa72-marvell_macchiatobin-squashfs-sdcard.img.gz",
-        "openwrt-mvebu-cortexa72-marvell_macchiatobin-ext4-sdcard.img.gz"
-      ]
-    },
-    "SolidRun Armada 8040 Community Board": {
-      "id": "marvell_macchiatobin",
-      "target": "mvebu/cortexa72",
-      "images": [
-        "openwrt-mvebu-cortexa72-marvell_macchiatobin-squashfs-sdcard.img.gz",
-        "openwrt-mvebu-cortexa72-marvell_macchiatobin-ext4-sdcard.img.gz"
-      ]
-    },
-    "Marvell Armada 7040 Development Board": {
-      "id": "marvell_armada7040-db",
-      "target": "mvebu/cortexa72",
-      "images": [
-        "openwrt-mvebu-cortexa72-marvell_armada7040-db-squashfs-sdcard.img.gz",
-        "openwrt-mvebu-cortexa72-marvell_armada7040-db-ext4-sdcard.img.gz"
-      ]
-    },
-    "Marvell Armada 8040 Development Board": {
-      "id": "marvell_armada8040-db",
-      "target": "mvebu/cortexa72",
-      "images": [
-        "openwrt-mvebu-cortexa72-marvell_armada8040-db-squashfs-sdcard.img.gz",
-        "openwrt-mvebu-cortexa72-marvell_armada8040-db-ext4-sdcard.img.gz"
-      ]
-    },
-    "Linksys WRT32X": {
-      "id": "linksys_wrt32x",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt32x-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt32x-squashfs-factory.img"
-      ]
-    },
-    "Linksys Venom": {
-      "id": "linksys_wrt32x",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt32x-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt32x-squashfs-factory.img"
-      ]
-    },
-    "Marvell Armada 370 Development Board (DB-88F6710-BP-DDR3)": {
-      "id": "marvell_a370-db",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-marvell_a370-db-squashfs-sysupgrade.bin"
-      ]
-    },
-    "SolidRun ClearFog Base": {
-      "id": "solidrun_clearfog-base-a1",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-solidrun_clearfog-base-a1-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Linksys WRT1900ACS v1": {
-      "id": "linksys_wrt1900acs",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-factory.img"
-      ]
-    },
-    "Linksys WRT1900ACS v2": {
-      "id": "linksys_wrt1900acs",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-factory.img"
-      ]
-    },
-    "Linksys Shelby": {
-      "id": "linksys_wrt1900acs",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-factory.img"
-      ]
-    },
-    "Marvell Armada 385 Development Board AP (DB-88F6820-AP)": {
-      "id": "marvell_a385-db-ap",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-marvell_a385-db-ap-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-marvell_a385-db-ap-squashfs-factory.img"
-      ]
-    },
-    "Linksys WRT1200AC": {
-      "id": "linksys_wrt1200ac",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1200ac-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1200ac-squashfs-factory.img"
-      ]
-    },
-    "Linksys Caiman": {
-      "id": "linksys_wrt1200ac",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1200ac-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1200ac-squashfs-factory.img"
-      ]
-    },
-    "Marvell Armada 370 RD (RD-88F6710-A1)": {
-      "id": "marvell_a370-rd",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-marvell_a370-rd-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Linksys WRT1900AC v2": {
-      "id": "linksys_wrt1900acv2",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acv2-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acv2-squashfs-factory.img"
-      ]
-    },
-    "Linksys Cobra": {
-      "id": "linksys_wrt1900acv2",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acv2-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1900acv2-squashfs-factory.img"
-      ]
-    },
-    "Plat'Home OpenBlocks AX3 4 ports": {
-      "id": "plathome_openblocks-ax3-4",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-plathome_openblocks-ax3-4-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-plathome_openblocks-ax3-4-squashfs-factory.img"
-      ]
-    },
-    "CZ.NIC Turris Omnia": {
-      "id": "cznic_turris-omnia",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "omnia-medkit-openwrt-mvebu-cortexa9-cznic_turris-omnia-initramfs.tar.gz",
-        "openwrt-mvebu-cortexa9-cznic_turris-omnia-sysupgrade.img.gz"
-      ]
-    },
-    "SolidRun ClearFog Pro": {
-      "id": "solidrun_clearfog-pro-a1",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-solidrun_clearfog-pro-a1-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Linksys WRT3200ACM": {
-      "id": "linksys_wrt3200acm",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt3200acm-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt3200acm-squashfs-factory.img"
-      ]
-    },
-    "Linksys Rango": {
-      "id": "linksys_wrt3200acm",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt3200acm-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt3200acm-squashfs-factory.img"
-      ]
-    },
-    "Marvell Armada XP Development Board (DB-78460-BP)": {
-      "id": "marvell_axp-db",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-marvell_axp-db-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Marvell Armada 388 RD (RD-88F6820-AP)": {
-      "id": "marvell_a388-rd",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-marvell_a388-rd-squashfs-firmware.bin"
-      ]
-    },
-    "Linksys WRT1900AC v1": {
-      "id": "linksys_wrt1900ac",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1900ac-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1900ac-squashfs-factory.img"
-      ]
-    },
-    "Linksys Mamba": {
-      "id": "linksys_wrt1900ac",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-linksys_wrt1900ac-squashfs-sysupgrade.bin",
-        "openwrt-mvebu-cortexa9-linksys_wrt1900ac-squashfs-factory.img"
-      ]
-    },
-    "Marvell Armada Armada XP GP (DB-MV784MP-GP)": {
-      "id": "marvell_axp-gp",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-marvell_axp-gp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Globalscale Mirabox": {
-      "id": "globalscale_mirabox",
-      "target": "mvebu/cortexa9",
-      "images": [
-        "openwrt-mvebu-cortexa9-globalscale_mirabox-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Marvell ESPRESSObin V7 Non-eMMC": {
-      "id": "globalscale_espressobin-v7",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-ext4-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Marvell Armada 3700 Community Board V7 Non-eMMC": {
-      "id": "globalscale_espressobin-v7",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-ext4-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Marvell ESPRESSObin Non-eMMC": {
-      "id": "globalscale_espressobin",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-squashfs-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-ext4-sdcard.img.gz"
-      ]
-    },
-    "Marvell Armada 3700 Community Board Non-eMMC": {
-      "id": "globalscale_espressobin",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-squashfs-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-ext4-sdcard.img.gz"
-      ]
-    },
-    "Marvell ESPRESSObin eMMC": {
-      "id": "globalscale_espressobin-emmc",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-emmc-squashfs-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-emmc-ext4-sdcard.img.gz"
-      ]
-    },
-    "Marvell Armada 3700 Community Board eMMC": {
-      "id": "globalscale_espressobin-emmc",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-emmc-squashfs-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-emmc-ext4-sdcard.img.gz"
-      ]
-    },
-    "Marvell Armada 3720 Development Board (DB-88F3720-DDR3)": {
-      "id": "marvell_armada-3720-db",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-marvell_armada-3720-db-ext4-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-marvell_armada-3720-db-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Methode micro-DPU (uDPU)": {
-      "id": "methode_udpu",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-methode_udpu-firmware.tgz"
-      ]
-    },
-    "Marvell ESPRESSObin V7 eMMC": {
-      "id": "globalscale_espressobin-v7-emmc",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-emmc-ext4-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-emmc-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Marvell Armada 3700 Community Board V7 eMMC": {
-      "id": "globalscale_espressobin-v7-emmc",
-      "target": "mvebu/cortexa53",
-      "images": [
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-emmc-ext4-sdcard.img.gz",
-        "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-emmc-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Buffalo WBMR-HP-G300H B": {
-      "id": "buffalo_wbmr-hp-g300h-b",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-buffalo_wbmr-hp-g300h-b-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV7518PW": {
-      "id": "arcadyan_arv7518pw",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv7518pw-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Astoria Networks ARV7518PW": {
-      "id": "arcadyan_arv7518pw",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv7518pw-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZTE H201L": {
-      "id": "zte_h201l",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-zte_h201l-squashfs-sysupgrade.bin"
-      ]
-    },
-    "British Telecom Home Hub 3 Type A": {
-      "id": "bt_homehub-v3a",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-bt_homehub-v3a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV752DPW": {
-      "id": "arcadyan_arv752dpw",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv752dpw-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Vodafone Easybox 802": {
-      "id": "arcadyan_arv752dpw",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv752dpw-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR DGN3500B": {
-      "id": "netgear_dgn3500b",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-netgear_dgn3500b-squashfs-sysupgrade.bin",
-        "openwrt-lantiq-xway-netgear_dgn3500b-squashfs-factory.img"
-      ]
-    },
-    "AVM FRITZ!Box 7320": {
-      "id": "avm_fritz7320",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-avm_fritz7320-squashfs-sysupgrade.bin"
-      ]
-    },
     "1&1 HomeServer": {
       "id": "avm_fritz7320",
-      "target": "lantiq/xway",
       "images": [
-        "openwrt-lantiq-xway-avm_fritz7320-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV7506PW11": {
-      "id": "arcadyan_arv7506pw11",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv7506pw11-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Alice/O2 IAD 4421": {
-      "id": "arcadyan_arv7506pw11",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv7506pw11-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV752DPW22": {
-      "id": "arcadyan_arv752dpw22",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv752dpw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Vodafone Easybox 803": {
-      "id": "arcadyan_arv752dpw22",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv752dpw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV7519PW": {
-      "id": "arcadyan_arv7519pw",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv7519pw-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Astoria Networks ARV7519PW": {
-      "id": "arcadyan_arv7519pw",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv7519pw-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Siemens Gigaset sx76x": {
-      "id": "siemens_gigaset-sx76x",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-siemens_gigaset-sx76x-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR DGN3500": {
-      "id": "netgear_dgn3500",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-netgear_dgn3500-squashfs-sysupgrade-na.bin",
-        "openwrt-lantiq-xway-netgear_dgn3500-squashfs-sysupgrade.bin",
-        "openwrt-lantiq-xway-netgear_dgn3500-squashfs-factory-na.img",
-        "openwrt-lantiq-xway-netgear_dgn3500-squashfs-factory.img"
-      ]
-    },
-    "ZyXEL P-2601HN F1/F3": {
-      "id": "zyxel_p-2601hn",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-zyxel_p-2601hn-squashfs-sysupgrade.bin"
-      ]
-    },
-    "British Telecom Home Hub 2 Type B": {
-      "id": "bt_homehub-v2b",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-bt_homehub-v2b-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq Danube (EASY50712)": {
-      "id": "lantiq_easy50712",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-lantiq_easy50712-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AudioCodes MediaPack MP-252": {
-      "id": "audiocodes_mp-252",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-audiocodes_mp-252-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV8539PW22": {
-      "id": "arcadyan_arv8539pw22",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv8539pw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Telekom Speedport W504V Typ A": {
-      "id": "arcadyan_arv8539pw22",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv8539pw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV4510PW": {
-      "id": "arcadyan_arv4510pw",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv4510pw-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Wippies BeWan iBox v1.0": {
-      "id": "arcadyan_arv4510pw",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv4510pw-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AVM FRITZ!Box 7312": {
-      "id": "avm_fritz7312",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-avm_fritz7312-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV7510PW22": {
-      "id": "arcadyan_arv7510pw22",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv7510pw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Astoria Networks ARV7510PW22": {
-      "id": "arcadyan_arv7510pw22",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-arcadyan_arv7510pw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WBMR-HP-G300H A": {
-      "id": "buffalo_wbmr-hp-g300h-a",
-      "target": "lantiq/xway",
-      "images": [
-        "openwrt-lantiq-xway-buffalo_wbmr-hp-g300h-a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq Falcon SFP Stick": {
-      "id": "lantiq_falcon-sfp",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_falcon-sfp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq Falcon HGU Reference Board (EASY98021)": {
-      "id": "lantiq_easy98021",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy98021-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq EASY98000 Falcon Eval Board NAND": {
-      "id": "lantiq_easy98000-nand",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy98000-nand-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq EASY98000 Falcon Eval Board NOR": {
-      "id": "lantiq_easy98000-nor",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy98000-nor-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq Falcon SFU Reference Board (EASY98020) v1.8": {
-      "id": "lantiq_easy98020-v18",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy98020-v18-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq Falcon / VINAXdp MDU Board": {
-      "id": "lantiq_falcon-mdu",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_falcon-mdu-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq EASY88444 Falcon FTTdp G.FAST Reference Board": {
-      "id": "lantiq_easy88444",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy88444-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq Falcon SFU Reference Board (EASY98020) v1.0-v1.7": {
-      "id": "lantiq_easy98020",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy98020-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq EASY88388 Falcon FTTDP8 Reference Board": {
-      "id": "lantiq_easy88388",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy88388-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq Falcon SFP Stick (EASY98035SYNCE1588) with SyncE and IEEE1588": {
-      "id": "lantiq_easy98035synce1588",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy98035synce1588-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq EASY98000 Falcon Eval Board SFLASH": {
-      "id": "lantiq_easy98000-sflash",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy98000-sflash-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq Falcon SFP Stick (EASY98035SYNCE) with Synchronous Ethernet": {
-      "id": "lantiq_easy98035synce",
-      "target": "lantiq/falcon",
-      "images": [
-        "openwrt-lantiq-falcon-lantiq_easy98035synce-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer VR200 v1": {
-      "id": "tplink_vr200",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-tplink_vr200-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZyXEL P-2812HNU F1": {
-      "id": "zyxel_p-2812hnu-f1",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-zyxel_p-2812hnu-f1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer VR200v v1": {
-      "id": "tplink_vr200v",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-tplink_vr200v-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan VGV7519 NOR": {
-      "id": "arcadyan_vgv7519-nor",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vgv7519-nor-squashfs-sysupgrade.bin"
-      ]
-    },
-    "KPN Experiabox 8 NOR": {
-      "id": "arcadyan_vgv7519-nor",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vgv7519-nor-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TD-W8980 v1": {
-      "id": "tplink_tdw8980",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-tplink_tdw8980-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan ARV7519RW22": {
-      "id": "arcadyan_arv7519rw22",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_arv7519rw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Orange Livebox 2.1": {
-      "id": "arcadyan_arv7519rw22",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_arv7519rw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Astoria Networks ARV7519RW22": {
-      "id": "arcadyan_arv7519rw22",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_arv7519rw22-squashfs-sysupgrade.bin"
-      ]
-    },
-    "BT Openreach ECI VDSL Modem V-2FUb/R": {
-      "id": "arcadyan_vg3503j",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vg3503j-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Arcadyan VGV7510KW22 BRN": {
-      "id": "arcadyan_vgv7510kw22-brn",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vgv7510kw22-brn-squashfs-factory.bin"
-      ]
-    },
-    "o2 Box 6431 BRN": {
-      "id": "arcadyan_vgv7510kw22-brn",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vgv7510kw22-brn-squashfs-factory.bin"
-      ]
-    },
-    "Lantiq VR9 EASY80920 NAND": {
-      "id": "lantiq_easy80920-nand",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-lantiq_easy80920-nand-squashfs-sysupgrade.bin",
-        "openwrt-lantiq-xrx200-lantiq_easy80920-nand-squashfs-fullimage.bin"
-      ]
-    },
-    "Arcadyan VGV7519 BRN": {
-      "id": "arcadyan_vgv7519-brn",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vgv7519-brn-squashfs-factory.bin"
-      ]
-    },
-    "KPN Experiabox 8 BRN": {
-      "id": "arcadyan_vgv7519-brn",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vgv7519-brn-squashfs-factory.bin"
-      ]
-    },
-    "Arcadyan VGV7510KW22 NOR": {
-      "id": "arcadyan_vgv7510kw22-nor",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vgv7510kw22-nor-squashfs-sysupgrade.bin"
-      ]
-    },
-    "o2 Box 6431 NOR": {
-      "id": "arcadyan_vgv7510kw22-nor",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-arcadyan_vgv7510kw22-nor-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AVM FRITZ!Box 7360 SL": {
-      "id": "avm_fritz7360sl",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-avm_fritz7360sl-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AVM FRITZ!Box 3370 Rev. 2 (Hynix NAND)": {
-      "id": "avm_fritz3370-rev2-hynix",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-avm_fritz3370-rev2-hynix-squashfs-eva-kernel.bin",
-        "openwrt-lantiq-xrx200-avm_fritz3370-rev2-hynix-squashfs-eva-filesystem.bin",
-        "openwrt-lantiq-xrx200-avm_fritz3370-rev2-hynix-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WBMR-300HPD": {
-      "id": "buffalo_wbmr-300hpd",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-buffalo_wbmr-300hpd-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AVM FRITZ!Box 7362 SL": {
-      "id": "avm_fritz7362sl",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-avm_fritz7362sl-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZyXEL P-2812HNU F3": {
-      "id": "zyxel_p-2812hnu-f3",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-zyxel_p-2812hnu-f3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AVM FRITZ!Box 7412": {
-      "id": "avm_fritz7412",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-avm_fritz7412-squashfs-sysupgrade.bin"
-      ]
-    },
-    "British Telecom Home Hub 5 Type A": {
-      "id": "bt_homehub-v5a",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-bt_homehub-v5a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lantiq VR9 EASY80920 NOR": {
-      "id": "lantiq_easy80920-nor",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-lantiq_easy80920-nor-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Alpha ASL56026": {
-      "id": "alphanetworks_asl56026",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-alphanetworks_asl56026-squashfs-sysupgrade.bin"
-      ]
-    },
-    "BT Openreach ECI VDSL Modem V-2FUb/I": {
-      "id": "alphanetworks_asl56026",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-alphanetworks_asl56026-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AVM FRITZ!Box 3370 Rev. 2 (Micron NAND)": {
-      "id": "avm_fritz3370-rev2-micron",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-avm_fritz3370-rev2-micron-squashfs-sysupgrade.bin",
-        "openwrt-lantiq-xrx200-avm_fritz3370-rev2-micron-squashfs-eva-kernel.bin",
-        "openwrt-lantiq-xrx200-avm_fritz3370-rev2-micron-squashfs-eva-filesystem.bin"
-      ]
-    },
-    "TP-Link TD-W8970 v1": {
-      "id": "tplink_tdw8970",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-tplink_tdw8970-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR DM200": {
-      "id": "netgear_dm200",
-      "target": "lantiq/xrx200",
-      "images": [
-        "openwrt-lantiq-xrx200-netgear_dm200-squashfs-sysupgrade.bin",
-        "openwrt-lantiq-xrx200-netgear_dm200-squashfs-factory.img"
-      ]
-    },
-    "Allnet ALL0333CJ": {
-      "id": "allnet_all0333cj",
-      "target": "lantiq/ase",
-      "images": [
-        "openwrt-lantiq-ase-allnet_all0333cj-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR DGN1000B": {
-      "id": "netgear_dgn1000b",
-      "target": "lantiq/ase",
-      "images": [
-        "openwrt-lantiq-ase-netgear_dgn1000b-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR WNR2200 16M": {
-      "id": "netgear_wnr2200-16m",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_wnr2200-16m-squashfs-factory.img",
-        "openwrt-ath79-generic-netgear_wnr2200-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR WNR2200 CN/RU": {
-      "id": "netgear_wnr2200-16m",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_wnr2200-16m-squashfs-factory.img",
-        "openwrt-ath79-generic-netgear_wnr2200-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C7 v5": {
-      "id": "tplink_archer-c7-v5",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c7-v5-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c7-v5-squashfs-factory.bin"
-      ]
-    },
-    "D-Link DIR-835 A1": {
-      "id": "dlink_dir-835-a1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-dlink_dir-835-a1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-dlink_dir-835-a1-squashfs-factory.bin"
-      ]
-    },
-    "AVM FRITZ!WLAN Repeater 300E": {
-      "id": "avm_fritz300e",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-avm_fritz300e-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link CPE220 v3": {
-      "id": "tplink_cpe220-v3",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe220-v3-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe220-v3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WZR-HP-G302H A1A0": {
-      "id": "buffalo_wzr-hp-g302h-a1a0",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-buffalo_wzr-hp-g302h-a1a0-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-buffalo_wzr-hp-g302h-a1a0-squashfs-factory.bin",
-        "openwrt-ath79-generic-buffalo_wzr-hp-g302h-a1a0-squashfs-tftp.bin"
-      ]
-    },
-    "TP-Link TL-WR1043N/ND v3": {
-      "id": "tplink_tl-wr1043nd-v3",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr1043nd-v3-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr1043nd-v3-squashfs-factory.bin"
-      ]
-    },
-    "ELECOM WRC-1750GHBK2-I/C": {
-      "id": "elecom_wrc-1750ghbk2-i",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-elecom_wrc-1750ghbk2-i-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR842N/ND v1": {
-      "id": "tplink_tl-wr842n-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr842n-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr842n-v1-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti Nanostation AC": {
-      "id": "ubnt_nanostation-ac",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_nanostation-ac-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_nanostation-ac-squashfs-factory.bin"
-      ]
-    },
-    "Western Digital My Net Wi-Fi Range Extender": {
-      "id": "wd_mynet-wifi-rangeextender",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-wd_mynet-wifi-rangeextender-squashfs-sysupgrade.bin"
-      ]
-    },
-    "jjPlus JA76PF2": {
-      "id": "jjplus_ja76pf2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-jjplus_ja76pf2-squashfs-kernel.bin",
-        "openwrt-ath79-generic-jjplus_ja76pf2-squashfs-rootfs.bin"
-      ]
-    },
-    "PowerCloud Systems CR5000": {
-      "id": "pcs_cr5000",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-pcs_cr5000-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link RE350K v1": {
-      "id": "tplink_re350k-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_re350k-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_re350k-v1-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR1043N/ND v2": {
-      "id": "tplink_tl-wr1043nd-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr1043nd-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr1043nd-v2-squashfs-factory.bin"
-      ]
-    },
-    "COMFAST CF-E110N v2": {
-      "id": "comfast_cf-e110n-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-comfast_cf-e110n-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "I-O DATA WN-AC1600DGR": {
-      "id": "iodata_wn-ac1600dgr",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-iodata_wn-ac1600dgr-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti UniFi": {
-      "id": "ubnt_unifi",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_unifi-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_unifi-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti EdgeSwitch 5XP": {
-      "id": "ubnt_edgeswitch-5xp",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_edgeswitch-5xp-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_edgeswitch-5xp-squashfs-factory.bin"
-      ]
-    },
-    "OpenMesh OM5P-AC v2": {
-      "id": "openmesh_om5p-ac-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-openmesh_om5p-ac-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZBT WD323": {
-      "id": "zbtlink_zbt-wd323",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-zbtlink_zbt-wd323-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR WNDR3700 v2": {
-      "id": "netgear_wndr3700v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_wndr3700v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-netgear_wndr3700v2-squashfs-factory.img"
-      ]
-    },
-    "TP-Link TL-WR902AC v1": {
-      "id": "tplink_tl-wr902ac-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr902ac-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr902ac-v1-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR EX7300": {
-      "id": "netgear_ex7300",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_ex7300-squashfs-factory.img",
-        "openwrt-ath79-generic-netgear_ex7300-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti UniFi AC-Pro": {
-      "id": "ubnt_unifiac-pro",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_unifiac-pro-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti Nanostation M XW": {
-      "id": "ubnt_nanostation-m-xw",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_nanostation-m-xw-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_nanostation-m-xw-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti Bullet-M XW": {
-      "id": "ubnt_bullet-m-xw",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_bullet-m-xw-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_bullet-m-xw-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C6 v2 (US)": {
-      "id": "tplink_archer-c6-v2-us",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer A6 v2 (US/TW)": {
-      "id": "tplink_archer-c6-v2-us",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-factory.bin"
-      ]
-    },
-    "eTactica EG200": {
-      "id": "etactica_eg200",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-etactica_eg200-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti NanoBeam AC": {
-      "id": "ubnt_nanobeam-ac",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_nanobeam-ac-squashfs-factory.bin",
-        "openwrt-ath79-generic-ubnt_nanobeam-ac-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-X750": {
-      "id": "glinet_gl-x750",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-glinet_gl-x750-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WDR4300 v1": {
-      "id": "tplink_tl-wdr4300-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wdr4300-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wdr4300-v1-squashfs-factory.bin"
-      ]
-    },
-    "GL.iNet GL-AR300M Lite": {
-      "id": "glinet_gl-ar300m-lite",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-glinet_gl-ar300m-lite-squashfs-sysupgrade.bin"
-      ]
-    },
-    "YunCore XD4200": {
-      "id": "yuncore_xd4200",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-yuncore_xd4200-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-yuncore_xd4200-squashfs-tftp.bin"
-      ]
-    },
-    "Aruba AP-105": {
-      "id": "aruba_ap-105",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-aruba_ap-105-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Qihoo C301": {
-      "id": "qihoo_c301",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-qihoo_c301-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-qihoo_c301-squashfs-factory.bin"
-      ]
-    },
-    "COMFAST CF-E314N v2": {
-      "id": "comfast_cf-e314n-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-comfast_cf-e314n-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Western Digital My Net N750": {
-      "id": "wd_mynet-n750",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-wd_mynet-n750-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-wd_mynet-n750-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C58 v1": {
-      "id": "tplink_archer-c58-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c58-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c58-v1-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR WNDR3800": {
-      "id": "netgear_wndr3800",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_wndr3800-squashfs-factory.img",
-        "openwrt-ath79-generic-netgear_wndr3800-squashfs-sysupgrade.bin"
-      ]
-    },
-    "COMFAST CF-WR650AC v2": {
-      "id": "comfast_cf-wr650ac-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-comfast_cf-wr650ac-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti LiteBeam AC Gen2": {
-      "id": "ubnt_litebeam-ac-gen2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_litebeam-ac-gen2-squashfs-factory.bin",
-        "openwrt-ath79-generic-ubnt_litebeam-ac-gen2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C6 v2 (EU/RU/JP)": {
-      "id": "tplink_archer-c6-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c6-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c6-v2-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WDR3500 v1": {
-      "id": "tplink_tl-wdr3500-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wdr3500-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wdr3500-v1-squashfs-factory.bin"
-      ]
-    },
-    "GL.iNet GL-AR300M16": {
-      "id": "glinet_gl-ar300m16",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-glinet_gl-ar300m16-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-859 A1": {
-      "id": "dlink_dir-859-a1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-dlink_dir-859-a1-squashfs-factory.bin",
-        "openwrt-ath79-generic-dlink_dir-859-a1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti UniFi AC-LR": {
-      "id": "ubnt_unifiac-lr",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_unifiac-lr-squashfs-sysupgrade.bin"
-      ]
-    },
-    "devolo WiFi pro 1200e": {
-      "id": "devolo_dvl1200e",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-devolo_dvl1200e-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR842N v3": {
-      "id": "tplink_tl-wr842n-v3",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr842n-v3-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr842n-v3-squashfs-factory.bin"
-      ]
-    },
-    "I-O DATA WN-AC1600DGR2/DGR3": {
-      "id": "iodata_wn-ac1600dgr2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-iodata_wn-ac1600dgr2-squashfs-dgr2-dgr3-factory.bin"
-      ]
-    },
-    "devolo WiFi pro 1750x": {
-      "id": "devolo_dvl1750x",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-devolo_dvl1750x-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti Bullet-M XM": {
-      "id": "ubnt_bullet-m",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_bullet-m-squashfs-factory.bin",
-        "openwrt-ath79-generic-ubnt_bullet-m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR WNDR3700 v1": {
-      "id": "netgear_wndr3700",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_wndr3700-squashfs-factory.img",
-        "openwrt-ath79-generic-netgear_wndr3700-squashfs-factory-NA.img",
-        "openwrt-ath79-generic-netgear_wndr3700-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer A7 v5": {
-      "id": "tplink_archer-a7-v5",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-a7-v5-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C7 v2": {
-      "id": "tplink_archer-c7-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c7-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c7-v2-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_archer-c7-v2-squashfs-factory-us.bin",
-        "openwrt-ath79-generic-tplink_archer-c7-v2-squashfs-factory-eu.bin"
-      ]
-    },
-    "Ubiquiti LiteAP ac LAP-120": {
-      "id": "ubnt_lap-120",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_lap-120-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_lap-120-squashfs-factory.bin"
-      ]
-    },
-    "Librerouter LibreRouter v1": {
-      "id": "librerouter_librerouter-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-librerouter_librerouter-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR EX6400": {
-      "id": "netgear_ex6400",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_ex6400-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-netgear_ex6400-squashfs-factory.img"
-      ]
-    },
-    "NETGEAR WNR2200 8M": {
-      "id": "netgear_wnr2200-8m",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_wnr2200-8m-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-netgear_wnr2200-8m-squashfs-factory.img",
-        "openwrt-ath79-generic-netgear_wnr2200-8m-squashfs-factory-NA.img"
-      ]
-    },
-    "Buffalo WZR-HP-G450H/WZR-450HP": {
-      "id": "buffalo_wzr-hp-g450h",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-buffalo_wzr-hp-g450h-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-buffalo_wzr-hp-g450h-squashfs-factory.bin",
-        "openwrt-ath79-generic-buffalo_wzr-hp-g450h-squashfs-tftp.bin"
-      ]
-    },
-    "TP-Link Archer C2 v3": {
-      "id": "tplink_archer-c2-v3",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c2-v3-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c2-v3-squashfs-factory.bin"
-      ]
-    },
-    "I-O DATA ETG3-R": {
-      "id": "iodata_etg3-r",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-iodata_etg3-r-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link WBS510 v2": {
-      "id": "tplink_wbs510-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_wbs510-v2-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_wbs510-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-MR6400 v1": {
-      "id": "tplink_tl-mr6400-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-mr6400-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-mr6400-v1-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer D50 v1": {
-      "id": "tplink_archer-d50-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-d50-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link RE355 v1": {
-      "id": "tplink_re355-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_re355-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_re355-v1-squashfs-factory.bin"
-      ]
-    },
-    "PowerCloud Systems CR3000": {
-      "id": "pcs_cr3000",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-pcs_cr3000-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-842 C2": {
-      "id": "dlink_dir-842-c2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-dlink_dir-842-c2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-dlink_dir-842-c2-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link CPE210 v3": {
-      "id": "tplink_cpe210-v3",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe210-v3-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe210-v3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-842 C3": {
-      "id": "dlink_dir-842-c3",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-dlink_dir-842-c3-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-dlink_dir-842-c3-squashfs-factory.bin"
-      ]
-    },
-    "PISEN TS-D084": {
-      "id": "pisen_ts-d084",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-pisen_ts-d084-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-pisen_ts-d084-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti RouterStation": {
-      "id": "ubnt_routerstation",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_routerstation-squashfs-factory.bin"
-      ]
-    },
-    "Phicomm K2T": {
-      "id": "phicomm_k2t",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-phicomm_k2t-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C60 v2": {
-      "id": "tplink_archer-c60-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c60-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c60-v2-squashfs-factory.bin"
-      ]
-    },
-    "PowerCloud Systems CAP324": {
-      "id": "pcs_cap324",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-pcs_cap324-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link WBS210 v2": {
-      "id": "tplink_wbs210-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_wbs210-v2-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_wbs210-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C7 v4": {
-      "id": "tplink_archer-c7-v4",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c7-v4-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c7-v4-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti Rocket-M XM": {
-      "id": "ubnt_rocket-m",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_rocket-m-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_rocket-m-squashfs-factory.bin"
-      ]
-    },
-    "Adtran/Bluesocket BSAP-1840": {
-      "id": "adtran_bsap1840",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-adtran_bsap1840-squashfs-kernel.bin",
-        "openwrt-ath79-generic-adtran_bsap1840-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-adtran_bsap1840-squashfs-rootfs.bin"
-      ]
-    },
-    "Adtran/Bluesocket BSAP-1800 v2": {
-      "id": "adtran_bsap1800-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-adtran_bsap1800-v2-squashfs-kernel.bin",
-        "openwrt-ath79-generic-adtran_bsap1800-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-adtran_bsap1800-v2-squashfs-rootfs.bin"
-      ]
-    },
-    "YunCore A782": {
-      "id": "yuncore_a782",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-yuncore_a782-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-yuncore_a782-squashfs-tftp.bin"
-      ]
-    },
-    "TP-Link TL-WR1043N v5": {
-      "id": "tplink_tl-wr1043n-v5",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr1043n-v5-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_tl-wr1043n-v5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "COMFAST CF-E313AC": {
-      "id": "comfast_cf-e313ac",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-comfast_cf-e313ac-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link RE450 v2": {
-      "id": "tplink_re450-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_re450-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_re450-v2-squashfs-factory.bin"
-      ]
-    },
-    "I-O DATA WN-AG300DGR": {
-      "id": "iodata_wn-ag300dgr",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-iodata_wn-ag300dgr-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-iodata_wn-ag300dgr-squashfs-factory.bin"
-      ]
-    },
-    "COMFAST CF-E5/E7": {
-      "id": "comfast_cf-e5",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-comfast_cf-e5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti UniFi AC-Mesh": {
-      "id": "ubnt_unifiac-mesh",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_unifiac-mesh-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR810N v1": {
-      "id": "tplink_tl-wr810n-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr810n-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr810n-v1-squashfs-factory.bin"
-      ]
-    },
-    "EnGenius EWS511AP": {
-      "id": "engenius_ews511ap",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-engenius_ews511ap-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NEC Aterm WG1200CR": {
-      "id": "nec_wg1200cr",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-nec_wg1200cr-squashfs-factory.bin",
-        "openwrt-ath79-generic-nec_wg1200cr-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WDR4300 v1 (IL)": {
-      "id": "tplink_tl-wdr4300-v1-il",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wdr4300-v1-il-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wdr4300-v1-il-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link CPE210 v1": {
-      "id": "tplink_cpe210-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe210-v1-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe210-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link CPE510 v2": {
-      "id": "tplink_cpe510-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe510-v2-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe510-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NEC Aterm WG800HP": {
-      "id": "nec_wg800hp",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-nec_wg800hp-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-nec_wg800hp-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti airCube ISP": {
-      "id": "ubnt_acb-isp",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_acb-isp-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_acb-isp-squashfs-factory.bin"
-      ]
-    },
-    "Buffalo WZR-HP-AG300H": {
-      "id": "buffalo_wzr-hp-ag300h",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-buffalo_wzr-hp-ag300h-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-buffalo_wzr-hp-ag300h-squashfs-factory.bin",
-        "openwrt-ath79-generic-buffalo_wzr-hp-ag300h-squashfs-tftp.bin"
-      ]
-    },
-    "TP-Link Archer C7 v1": {
-      "id": "tplink_archer-c7-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c7-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c7-v1-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WDR4900 v2": {
-      "id": "tplink_tl-wdr4900-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wdr4900-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wdr4900-v2-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti UniFi AC-Lite": {
-      "id": "ubnt_unifiac-lite",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_unifiac-lite-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WDR3600 v1": {
-      "id": "tplink_tl-wdr3600-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wdr3600-v1-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_tl-wdr3600-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR710N v1": {
-      "id": "tplink_tl-wr710n-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr710n-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr710n-v1-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link CPE210 v2": {
-      "id": "tplink_cpe210-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe210-v2-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe210-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MikroTik RouterBOARD wAP G-5HacT2HnD (wAP AC)": {
-      "id": "mikrotik_routerboard-wap-g-5hact2hnd",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-mikrotik_routerboard-wap-g-5hact2hnd-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ELECOM WRC-300GHBK2-I": {
-      "id": "elecom_wrc-300ghbk2-i",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-elecom_wrc-300ghbk2-i-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-AR150": {
-      "id": "glinet_gl-ar150",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-glinet_gl-ar150-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti RouterStation Pro": {
-      "id": "ubnt_routerstation-pro",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_routerstation-pro-squashfs-factory.bin"
-      ]
-    },
-    "EnGenius ECB1750": {
-      "id": "engenius_ecb1750",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-engenius_ecb1750-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR810N v2": {
-      "id": "tplink_tl-wr810n-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr810n-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr810n-v2-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR1043N/ND v4": {
-      "id": "tplink_tl-wr1043nd-v4",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr1043nd-v4-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_tl-wr1043nd-v4-squashfs-sysupgrade.bin"
-      ]
-    },
-    "YunCore A770": {
-      "id": "yuncore_a770",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-yuncore_a770-squashfs-tftp.bin",
-        "openwrt-ath79-generic-yuncore_a770-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ocedo Ursus": {
-      "id": "ocedo_ursus",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ocedo_ursus-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Sitecom WLR-7100 v1 002": {
-      "id": "sitecom_wlr-7100",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-sitecom_wlr-7100-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-sitecom_wlr-7100-squashfs-factory.dlf"
-      ]
-    },
-    "D-Link DIR-825 C1": {
-      "id": "dlink_dir-825-c1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-dlink_dir-825-c1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-dlink_dir-825-c1-squashfs-factory.bin"
-      ]
-    },
-    "Trendnet TEW-823DRU v1.0R": {
-      "id": "trendnet_tew-823dru",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-trendnet_tew-823dru-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-trendnet_tew-823dru-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C59 v2": {
-      "id": "tplink_archer-c59-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c59-v2-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_archer-c59-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Rosinson WR818": {
-      "id": "rosinson_wr818",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-rosinson_wr818-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link RE450 v1": {
-      "id": "tplink_re450-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_re450-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_re450-v1-squashfs-factory.bin"
-      ]
-    },
-    "Ocedo Raccoon": {
-      "id": "ocedo_raccoon",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ocedo_raccoon-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link CPE610 v1": {
-      "id": "tplink_cpe610-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe610-v1-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe610-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "COMFAST CF-WR650AC v1": {
-      "id": "comfast_cf-wr650ac-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-comfast_cf-wr650ac-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti Nanostation AC loco": {
-      "id": "ubnt_nanostation-ac-loco",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_nanostation-ac-loco-squashfs-factory.bin",
-        "openwrt-ath79-generic-ubnt_nanostation-ac-loco-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR1043N/ND v1": {
-      "id": "tplink_tl-wr1043nd-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr1043nd-v1-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_tl-wr1043nd-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "devolo WiFi pro 1750c": {
-      "id": "devolo_dvl1750c",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-devolo_dvl1750c-squashfs-sysupgrade.bin"
-      ]
-    },
-    "COMFAST CF-E120A v3": {
-      "id": "comfast_cf-e120a-v3",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-comfast_cf-e120a-v3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Embedded Wireless Dorin": {
-      "id": "embeddedwireless_dorin",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-embeddedwireless_dorin-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR842N/ND v2": {
-      "id": "tplink_tl-wr842n-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr842n-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr842n-v2-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C59 v1": {
-      "id": "tplink_archer-c59-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c59-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "PISEN WMB001N": {
-      "id": "pisen_wmb001n",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-pisen_wmb001n-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-pisen_wmb001n-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link CPE220 v2": {
-      "id": "tplink_cpe220-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe220-v2-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe220-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "PISEN Cloud Easy Power (WMM003N)": {
-      "id": "pisen_wmm003n",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-pisen_wmm003n-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-pisen_wmm003n-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C25 v1": {
-      "id": "tplink_archer-c25-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c25-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c25-v1-squashfs-factory.bin"
-      ]
-    },
-    "devolo WiFi pro 1750i": {
-      "id": "devolo_dvl1750i",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-devolo_dvl1750i-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-AR750": {
-      "id": "glinet_gl-ar750",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-glinet_gl-ar750-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link CPE510 v3": {
-      "id": "tplink_cpe510-v3",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe510-v3-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe510-v3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "I-O DATA WN-AC1167DGR": {
-      "id": "iodata_wn-ac1167dgr",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-iodata_wn-ac1167dgr-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-iodata_wn-ac1167dgr-squashfs-factory.bin"
-      ]
-    },
-    "Ocedo Koala": {
-      "id": "ocedo_koala",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ocedo_koala-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Xiaomi Mi Router 4Q": {
-      "id": "xiaomi_mi-router-4q",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-xiaomi_mi-router-4q-squashfs-sysupgrade.bin"
-      ]
-    },
-    "devolo WiFi pro 1750e": {
-      "id": "devolo_dvl1750e",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-devolo_dvl1750e-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link WBS510 v1": {
-      "id": "tplink_wbs510-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_wbs510-v1-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_wbs510-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link CPE510 v1": {
-      "id": "tplink_cpe510-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_cpe510-v1-squashfs-factory.bin",
-        "openwrt-ath79-generic-tplink_cpe510-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "8devices Carambola2": {
-      "id": "8dev_carambola2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-8dev_carambola2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti AirRouter XM": {
-      "id": "ubnt_airrouter",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_airrouter-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_airrouter-squashfs-factory.bin"
-      ]
-    },
-    "Buffalo BHR-4GRV2": {
-      "id": "buffalo_bhr-4grv2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-buffalo_bhr-4grv2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR WNDR3800CH": {
-      "id": "netgear_wndr3800ch",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-netgear_wndr3800ch-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-netgear_wndr3800ch-squashfs-factory.img"
-      ]
-    },
-    "EnGenius EPG5000": {
-      "id": "engenius_epg5000",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-engenius_epg5000-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-engenius_epg5000-squashfs-factory.dlf"
-      ]
-    },
-    "D-Link DIR-842 C1": {
-      "id": "dlink_dir-842-c1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-dlink_dir-842-c1-squashfs-factory.bin",
-        "openwrt-ath79-generic-dlink_dir-842-c1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti UniFi AC-Mesh Pro": {
-      "id": "ubnt_unifiac-mesh-pro",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_unifiac-mesh-pro-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR2543N/ND v1": {
-      "id": "tplink_tl-wr2543-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr2543-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr2543-v1-squashfs-factory.bin"
-      ]
-    },
-    "devolo WiFi pro 1200i": {
-      "id": "devolo_dvl1200i",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-devolo_dvl1200i-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-825 B1": {
-      "id": "dlink_dir-825-b1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-dlink_dir-825-b1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti Nanostation M XM": {
-      "id": "ubnt_nanostation-m",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_nanostation-m-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-ubnt_nanostation-m-squashfs-factory.bin"
-      ]
-    },
-    "Buffalo BHR-4GRV": {
-      "id": "buffalo_bhr-4grv",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-buffalo_bhr-4grv-squashfs-factory.bin"
-      ]
-    },
-    "D-Link DIR-505": {
-      "id": "dlink_dir-505",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-dlink_dir-505-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AVM FRITZ!Box 4020": {
-      "id": "avm_fritz4020",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-avm_fritz4020-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C5 v1": {
-      "id": "tplink_archer-c5-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c5-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c5-v1-squashfs-factory.bin"
-      ]
-    },
-    "Winchannel WB2000": {
-      "id": "winchannel_wb2000",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-winchannel_wb2000-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C60 v1": {
-      "id": "tplink_archer-c60-v1",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_archer-c60-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_archer-c60-v1-squashfs-factory.bin"
-      ]
-    },
-    "Ubiquiti EdgeSwitch 8XP": {
-      "id": "ubnt_edgeswitch-8xp",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-ubnt_edgeswitch-8xp-squashfs-factory.bin",
-        "openwrt-ath79-generic-ubnt_edgeswitch-8xp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR1045ND v2": {
-      "id": "tplink_tl-wr1045nd-v2",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-tplink_tl-wr1045nd-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-generic-tplink_tl-wr1045nd-v2-squashfs-factory.bin"
-      ]
-    },
-    "ALFA Network AP121F": {
-      "id": "alfa-network_ap121f",
-      "target": "ath79/generic",
-      "images": [
-        "openwrt-ath79-generic-alfa-network_ap121f-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR941ND v2/v3": {
-      "id": "tplink_tl-wr941-v2",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr941-v2-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr941-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR941N v2/v3": {
-      "id": "tplink_tl-wr941-v2",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr941-v2-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr941-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR841N/ND v7": {
-      "id": "tplink_tl-wr841-v7",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr841-v7-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v7-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR941ND v6": {
-      "id": "tplink_tl-wr941nd-v6",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr941nd-v6-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr941nd-v6-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR841N/ND v8": {
-      "id": "tplink_tl-wr841-v8",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr841-v8-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v8-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR940N v4": {
-      "id": "tplink_tl-wr940n-v4",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-factory-us.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-factory-eu.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-factory-br.bin"
-      ]
-    },
-    "TP-Link TL-WR741N/ND v4": {
-      "id": "tplink_tl-wr741nd-v4",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr741nd-v4-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr741nd-v4-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR841N/ND v11": {
-      "id": "tplink_tl-wr841-v11",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr841-v11-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v11-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v11-squashfs-factory-us.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v11-squashfs-factory-eu.bin"
-      ]
-    },
-    "TP-Link TL-WR941N v7 (CN)": {
-      "id": "tplink_tl-wr941n-v7-cn",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr941n-v7-cn-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr941n-v7-cn-squashfs-sysupgrade.bin"
-      ]
-    },
-    "PQI Air-Pen": {
-      "id": "pqi_air-pen",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-pqi_air-pen-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR741N/ND v1/v2": {
-      "id": "tplink_tl-wr741-v1",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr741-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr741-v1-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR WNR2000 v3": {
-      "id": "netgear_wnr2000-v3",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-netgear_wnr2000-v3-squashfs-factory.img",
-        "openwrt-ath79-tiny-netgear_wnr2000-v3-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-netgear_wnr2000-v3-squashfs-factory-NA.img"
-      ]
-    },
-    "TP-Link TL-WR841N/ND v10": {
-      "id": "tplink_tl-wr841-v10",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr841-v10-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v10-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR740N v1/v2": {
-      "id": "tplink_tl-wr740n-v1",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr740n-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr740n-v1-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR841N/ND v12": {
-      "id": "tplink_tl-wr841-v12",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr841-v12-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v12-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v12-squashfs-factory-us.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v12-squashfs-factory-eu.bin"
-      ]
-    },
-    "TP-Link TL-WR841N/ND v9": {
-      "id": "tplink_tl-wr841-v9",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr841-v9-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v9-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR941ND v4": {
-      "id": "tplink_tl-wr941-v4",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr941-v4-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr941-v4-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR941N v4": {
-      "id": "tplink_tl-wr941-v4",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr941-v4-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr941-v4-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR740N v4": {
-      "id": "tplink_tl-wr740n-v4",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr740n-v4-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr740n-v4-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR940N v3": {
-      "id": "tplink_tl-wr940n-v3",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr940n-v3-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr940n-v3-squashfs-factory.bin"
-      ]
-    },
-    "Buffalo WHR-G301N": {
-      "id": "buffalo_whr-g301n",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-buffalo_whr-g301n-squashfs-tftp.bin",
-        "openwrt-ath79-tiny-buffalo_whr-g301n-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-buffalo_whr-g301n-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WA850RE v1": {
-      "id": "tplink_tl-wa850re-v1",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wa850re-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wa850re-v1-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR740N v3": {
-      "id": "tplink_tl-wr740n-v3",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr740n-v3-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr740n-v3-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WA901ND v2": {
-      "id": "tplink_tl-wa901nd-v2",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wa901nd-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wa901nd-v2-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR WNR1000 v2": {
-      "id": "netgear_wnr1000-v2",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-netgear_wnr1000-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-netgear_wnr1000-v2-squashfs-factory.img"
-      ]
-    },
-    "On Networks N150R": {
-      "id": "on_n150r",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-on_n150r-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-on_n150r-squashfs-factory.img"
-      ]
-    },
-    "TP-Link TL-WR841N/ND v5/v6": {
-      "id": "tplink_tl-wr841-v5",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr841-v5-squashfs-factory.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr841-v5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR743ND v1": {
-      "id": "tplink_tl-wr743nd-v1",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-tplink_tl-wr743nd-v1-squashfs-sysupgrade.bin",
-        "openwrt-ath79-tiny-tplink_tl-wr743nd-v1-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR WNR612 v2": {
-      "id": "netgear_wnr612-v2",
-      "target": "ath79/tiny",
-      "images": [
-        "openwrt-ath79-tiny-netgear_wnr612-v2-squashfs-factory.img",
-        "openwrt-ath79-tiny-netgear_wnr612-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR WNDR3700 v4": {
-      "id": "netgear_wndr3700-v4",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-netgear_wndr3700-v4-squashfs-sysupgrade.bin",
-        "openwrt-ath79-nand-netgear_wndr3700-v4-squashfs-factory.img"
-      ]
-    },
-    "GL.iNet GL-AR300M NOR": {
-      "id": "glinet_gl-ar300m-nor",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-glinet_gl-ar300m-nor-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Aerohive HiveAP 121": {
-      "id": "aerohive_hiveap-121",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-aerohive_hiveap-121-squashfs-sysupgrade.bin",
-        "openwrt-ath79-nand-aerohive_hiveap-121-squashfs-factory.bin"
-      ]
-    },
-    "GL.iNet GL-AR750S NOR/NAND": {
-      "id": "glinet_gl-ar750s-nor-nand",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-glinet_gl-ar750s-nor-nand-squashfs-sysupgrade.bin",
-        "openwrt-ath79-nand-glinet_gl-ar750s-nor-nand-squashfs-factory.img"
-      ]
-    },
-    "GL.iNet GL-AR300M NAND": {
-      "id": "glinet_gl-ar300m-nand",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-glinet_gl-ar300m-nand-squashfs-sysupgrade.bin",
-        "openwrt-ath79-nand-glinet_gl-ar300m-nand-squashfs-factory.img"
-      ]
-    },
-    "NETGEAR WNDR4300 v2": {
-      "id": "netgear_wndr4300-v2",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-netgear_wndr4300-v2-squashfs-sysupgrade.bin",
-        "openwrt-ath79-nand-netgear_wndr4300-v2-squashfs-factory.img"
-      ]
-    },
-    "NETGEAR WNDR4300": {
-      "id": "netgear_wndr4300",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-netgear_wndr4300-squashfs-sysupgrade.bin",
-        "openwrt-ath79-nand-netgear_wndr4300-squashfs-factory.img"
-      ]
-    },
-    "NETGEAR WNDR4500 v3": {
-      "id": "netgear_wndr4500-v3",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-netgear_wndr4500-v3-squashfs-factory.img",
-        "openwrt-ath79-nand-netgear_wndr4500-v3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-AR750S NOR": {
-      "id": "glinet_gl-ar750s-nor",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-glinet_gl-ar750s-nor-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZyXEL NBG6716": {
-      "id": "zyxel_nbg6716",
-      "target": "ath79/nand",
-      "images": [
-        "openwrt-ath79-nand-zyxel_nbg6716-squashfs-sysupgrade.tar",
-        "openwrt-ath79-nand-zyxel_nbg6716-squashfs-factory.bin",
-        "openwrt-ath79-nand-zyxel_nbg6716-squashfs-sysupgrade-4M-Kernel.bin"
-      ]
-    },
-    "Digilent Zybo": {
-      "id": "digilent_zynq-zybo",
-      "target": "zynq",
-      "images": [
-        "openwrt-zynq-digilent_zynq-zybo-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Xilinx ZC702": {
-      "id": "xlnx_zynq-zc702",
-      "target": "zynq",
-      "images": [
-        "openwrt-zynq-xlnx_zynq-zc702-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Avnet ZedBoard": {
-      "id": "avnet_zynq-zed",
-      "target": "zynq",
-      "images": [
-        "openwrt-zynq-avnet_zynq-zed-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Digilent Zybo Z7": {
-      "id": "digilent_zynq-zybo-z7",
-      "target": "zynq",
-      "images": [
-        "openwrt-zynq-digilent_zynq-zybo-z7-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Ubiquiti EdgeRouter": {
-      "id": "ubnt_edgerouter",
-      "target": "octeon",
-      "images": [
-        "openwrt-octeon-ubnt_edgerouter-squashfs-sysupgrade.tar"
-      ]
-    },
-    "Ubiquiti EdgeRouter Lite": {
-      "id": "ubnt_edgerouter-lite",
-      "target": "octeon",
-      "images": [
-        "openwrt-octeon-ubnt_edgerouter-lite-squashfs-sysupgrade.tar"
-      ]
-    },
-    "MitraStar STG-212": {
-      "id": "mitrastar_stg-212",
-      "target": "oxnas/ox820",
-      "images": [
-        "openwrt-oxnas-ox820-mitrastar_stg-212-ubifs-ubinized.bin",
-        "openwrt-oxnas-ox820-mitrastar_stg-212-ubifs-sysupgrade.tar",
-        "openwrt-oxnas-ox820-mitrastar_stg-212-squashfs-ubinized.bin",
-        "openwrt-oxnas-ox820-mitrastar_stg-212-squashfs-sysupgrade.tar"
-      ]
-    },
-    "Shuttle KD20": {
-      "id": "shuttle_kd20",
-      "target": "oxnas/ox820",
-      "images": [
-        "openwrt-oxnas-ox820-shuttle_kd20-ubifs-ubinized.bin",
-        "openwrt-oxnas-ox820-shuttle_kd20-ubifs-sysupgrade.tar",
-        "openwrt-oxnas-ox820-shuttle_kd20-squashfs-ubinized.bin",
-        "openwrt-oxnas-ox820-shuttle_kd20-squashfs-sysupgrade.tar"
-      ]
-    },
-    "Cloud Engines PogoPlug Pro (with mPCIe)": {
-      "id": "cloudengines_pogoplugpro",
-      "target": "oxnas/ox820",
-      "images": [
-        "openwrt-oxnas-ox820-cloudengines_pogoplugpro-ubifs-ubinized.bin",
-        "openwrt-oxnas-ox820-cloudengines_pogoplugpro-ubifs-sysupgrade.tar",
-        "openwrt-oxnas-ox820-cloudengines_pogoplugpro-squashfs-ubinized.bin",
-        "openwrt-oxnas-ox820-cloudengines_pogoplugpro-squashfs-sysupgrade.tar"
-      ]
-    },
-    "Cloud Engines PogoPlug Series V3 (without mPCIe)": {
-      "id": "cloudengines_pogoplug-series-3",
-      "target": "oxnas/ox820",
-      "images": [
-        "openwrt-oxnas-ox820-cloudengines_pogoplug-series-3-ubifs-ubinized.bin",
-        "openwrt-oxnas-ox820-cloudengines_pogoplug-series-3-ubifs-sysupgrade.tar",
-        "openwrt-oxnas-ox820-cloudengines_pogoplug-series-3-squashfs-ubinized.bin",
-        "openwrt-oxnas-ox820-cloudengines_pogoplug-series-3-squashfs-sysupgrade.tar"
-      ]
-    },
-    "Akition myCloud mini": {
-      "id": "akitio_mycloud",
-      "target": "oxnas/ox820",
-      "images": [
-        "openwrt-oxnas-ox820-akitio_mycloud-ubifs-ubinized.bin",
-        "openwrt-oxnas-ox820-akitio_mycloud-ubifs-sysupgrade.tar",
-        "openwrt-oxnas-ox820-akitio_mycloud-squashfs-ubinized.bin",
-        "openwrt-oxnas-ox820-akitio_mycloud-squashfs-sysupgrade.tar"
-      ]
-    },
-    "NXP LS1088A-RDB Default": {
-      "id": "ls1088ardb",
-      "target": "layerscape/armv8_64b",
-      "images": [
-        "openwrt-layerscape-armv8_64b-ls1088ardb-ubifs-firmware.bin"
-      ]
-    },
-    "NXP LS1043A-RDB Default": {
-      "id": "ls1043ardb",
-      "target": "layerscape/armv8_64b",
-      "images": [
-        "openwrt-layerscape-armv8_64b-ls1043ardb-squashfs-firmware.bin"
-      ]
-    },
-    "NXP LS1012A-RDB": {
-      "id": "ls1012ardb",
-      "target": "layerscape/armv8_64b",
-      "images": [
-        "openwrt-layerscape-armv8_64b-ls1012ardb-ubifs-firmware.bin"
-      ]
-    },
-    "NXP LS2088ARDB": {
-      "id": "ls2088ardb",
-      "target": "layerscape/armv8_64b",
-      "images": [
-        "openwrt-layerscape-armv8_64b-ls2088ardb-squashfs-firmware.bin"
-      ]
-    },
-    "Traverse LS1043 Boards": {
-      "id": "traverse-ls1043",
-      "target": "layerscape/armv8_64b",
-      "images": [
-        "openwrt-layerscape-armv8_64b-traverse-ls1043-ubifs-root",
-        "openwrt-layerscape-armv8_64b-traverse-ls1043-ubifs-sysupgrade.bin"
-      ]
-    },
-    "NXP LS1046A-RDB Default": {
-      "id": "ls1046ardb",
-      "target": "layerscape/armv8_64b",
-      "images": [
-        "openwrt-layerscape-armv8_64b-ls1046ardb-ubifs-firmware.bin"
-      ]
-    },
-    "NXP TWR-LS1021A Default": {
-      "id": "ls1021atwr",
-      "target": "layerscape/armv7",
-      "images": [
-        "openwrt-layerscape-armv7-ls1021atwr-squashfs-firmware.bin"
-      ]
-    },
-    "Generic 96328avng": {
-      "id": "96328avng-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96328avng-generic-squashfs-cfe-4M.bin",
-        "openwrt-brcm63xx-smp-96328avng-generic-squashfs-cfe-8M.bin",
-        "openwrt-brcm63xx-smp-96328avng-generic-squashfs-cfe-16M.bin"
-      ]
-    },
-    "ADB P.DG AV4202N": {
-      "id": "AV4202N",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-AV4202N-squashfs-cfe.bin"
-      ]
-    },
-    "Huawei EchoLife HG520v": {
-      "id": "HG520v",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-HG520v-squashfs-cfe.bin"
-      ]
-    },
-    "Pirelli A226M-FWB": {
-      "id": "A226M-FWB",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-A226M-FWB-squashfs-cfe.bin"
-      ]
-    },
-    "Generic 96358VW2": {
-      "id": "96358VW2-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96358VW2-generic-squashfs-cfe.bin"
-      ]
-    },
-    "D-Link DSL-2650U": {
-      "id": "DSL2650U",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL2650U-squashfs-cfe.bin"
-      ]
-    },
-    "SFR Neufbox4 Sercomm": {
-      "id": "NEUFBOX4-SER",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-NEUFBOX4-SER-squashfs-cfe.bin"
-      ]
-    },
-    "Huawei EchoLife HG553": {
-      "id": "HG553",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-HG553-squashfs-cfe.bin"
-      ]
-    },
-    "SKY SR102": {
-      "id": "SR102",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-SR102-squashfs-cfe.bin"
-      ]
-    },
-    "Tecom GW6200": {
-      "id": "GW6200",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-GW6200-squashfs-cfe.bin"
-      ]
-    },
-    "Generic 96338W": {
-      "id": "96338W-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96338W-generic-squashfs-cfe.bin"
-      ]
-    },
-    "Comtrend VR-3025u": {
-      "id": "VR-3025u",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-VR-3025u-squashfs-sysupgrade.bin",
-        "openwrt-brcm63xx-smp-VR-3025u-squashfs-cfe.bin"
-      ]
-    },
-    "Generic 96348GW-10": {
-      "id": "96348GW-10-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96348GW-10-generic-squashfs-cfe.bin"
-      ]
-    },
-    "NETGEAR DGND3800B": {
-      "id": "DGND3800B",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DGND3800B-squashfs-factory.chk",
-        "openwrt-brcm63xx-smp-DGND3800B-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Comtrend AR-5387un": {
-      "id": "AR5387un",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-AR5387un-squashfs-sysupgrade.bin",
-        "openwrt-brcm63xx-smp-AR5387un-squashfs-cfe.bin"
-      ]
-    },
-    "D-Link DVA-G3810BN/TL": {
-      "id": "DVAG3810BN",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DVAG3810BN-squashfs-cfe.bin"
-      ]
-    },
-    "Comtrend VR-3025un": {
-      "id": "VR-3025un",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-VR-3025un-squashfs-cfe.bin"
-      ]
-    },
-    "Observa VH4032N": {
-      "id": "VH4032N",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-VH4032N-squashfs-sysupgrade.bin",
-        "openwrt-brcm63xx-smp-VH4032N-squashfs-cfe.bin"
-      ]
-    },
-    "Pirelli A226G": {
-      "id": "A226G",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-A226G-squashfs-cfe.bin"
-      ]
-    },
-    "ZyXEL P870HW-51a v2": {
-      "id": "P870HW-51a_v2",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-P870HW-51a_v2-squashfs-factory.bin"
-      ]
-    },
-    "Generic 96348GW": {
-      "id": "96348GW-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96348GW-generic-squashfs-cfe.bin",
-        "openwrt-brcm63xx-smp-96348GW-generic-squashfs-cfe-bc221.bin"
-      ]
-    },
-    "D-Link DSL-2740B F1": {
-      "id": "DSL274XB-F1",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL274XB-F1-squashfs-cfe-EU.bin",
-        "openwrt-brcm63xx-smp-DSL274XB-F1-squashfs-cfe-AU.bin"
-      ]
-    },
-    "D-Link DSL-2741B F1": {
-      "id": "DSL274XB-F1",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL274XB-F1-squashfs-cfe-EU.bin",
-        "openwrt-brcm63xx-smp-DSL274XB-F1-squashfs-cfe-AU.bin"
-      ]
-    },
-    "Sercomm AD1018 SPI flash mod": {
-      "id": "AD1018-SPI_flash",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-AD1018-SPI_flash-squashfs-cfe.bin"
-      ]
-    },
-    "Sagemcom F@st 2504N": {
-      "id": "FAST2504n",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-FAST2504n-squashfs-cfe.bin"
-      ]
-    },
-    "BT Home Hub 2.0 A": {
-      "id": "HomeHub2A",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-HomeHub2A-squashfs-cfe.bin"
-      ]
-    },
-    "NETGEAR DGND3700 v1": {
-      "id": "DGND3700v1",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DGND3700v1-squashfs-factory.chk",
-        "openwrt-brcm63xx-smp-DGND3700v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DSL-2740B C2": {
-      "id": "DSL274XB-C2",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL274XB-C2-squashfs-cfe.bin"
-      ]
-    },
-    "D-Link DSL-2741B C2": {
-      "id": "DSL274XB-C2",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL274XB-C2-squashfs-cfe.bin"
-      ]
-    },
-    "Comtrend WAP-5813n": {
-      "id": "WAP-5813n",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-WAP-5813n-squashfs-cfe.bin"
-      ]
-    },
-    "Generic 963281TAN": {
-      "id": "963281TAN-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-963281TAN-generic-squashfs-cfe-4M.bin",
-        "openwrt-brcm63xx-smp-963281TAN-generic-squashfs-cfe-8M.bin",
-        "openwrt-brcm63xx-smp-963281TAN-generic-squashfs-cfe-16M.bin"
-      ]
-    },
-    "D-Link DSL-2750B D1": {
-      "id": "DSL275XB-D1",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL275XB-D1-squashfs-cfe.bin"
-      ]
-    },
-    "D-Link DSL-2751 D1": {
-      "id": "DSL275XB-D1",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL275XB-D1-squashfs-cfe.bin"
-      ]
-    },
-    "Pirelli Alice Gate VoIP 2 Plus Wi-Fi AGPF-S0": {
-      "id": "AGPF-S0",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-AGPF-S0-squashfs-cfe.bin"
-      ]
-    },
-    "Generic 96368MVWG": {
-      "id": "96368MVWG-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96368MVWG-generic-squashfs-cfe.bin"
-      ]
-    },
-    "Comtrend CT-6373": {
-      "id": "CT-6373",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-CT-6373-squashfs-cfe.bin"
-      ]
-    },
-    "SFR Neufbox6": {
-      "id": "NEUFBOX6",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-NEUFBOX6-squashfs-cfe.bin"
-      ]
-    },
-    "NuCom R5010UN v2": {
-      "id": "R5010UNv2",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-R5010UNv2-squashfs-sysupgrade.bin",
-        "openwrt-brcm63xx-smp-R5010UNv2-squashfs-cfe.bin"
-      ]
-    },
-    "Comtrend VR-3026e": {
-      "id": "VR-3026e",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-VR-3026e-squashfs-cfe.bin"
-      ]
-    },
-    "Huawei EchoLife HG622": {
-      "id": "HG622",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-HG622-squashfs-cfe.bin",
-        "openwrt-brcm63xx-smp-HG622-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Comtrend AR-5315u": {
-      "id": "AR5315u",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-AR5315u-squashfs-cfe.bin",
-        "openwrt-brcm63xx-smp-AR5315u-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Generic 96358VW": {
-      "id": "96358VW-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96358VW-generic-squashfs-cfe.bin"
-      ]
-    },
-    "Generic 96368MVNgr": {
-      "id": "96368MVNgr-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96368MVNgr-generic-squashfs-cfe.bin"
-      ]
-    },
-    "Generic 96348GW-11": {
-      "id": "96348GW-11-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96348GW-11-generic-squashfs-cfe.bin"
-      ]
-    },
-    "ADB P.DG A4001N": {
-      "id": "A4001N",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-A4001N-squashfs-cfe.bin"
-      ]
-    },
-    "Pirelli A226M": {
-      "id": "A226M",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-A226M-squashfs-cfe.bin"
-      ]
-    },
-    "Actiontec R1000H": {
-      "id": "R1000H",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-R1000H-squashfs-cfe.bin"
-      ]
-    },
-    "Comtrend AR-5381u": {
-      "id": "AR5381u",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-AR5381u-squashfs-sysupgrade.bin",
-        "openwrt-brcm63xx-smp-AR5381u-squashfs-cfe.bin"
-      ]
-    },
-    "Generic 96338GW": {
-      "id": "96338GW-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96338GW-generic-squashfs-cfe.bin"
-      ]
-    },
-    "Telsey CPVA642-type (CPA-ZNTE60T)": {
-      "id": "CPA-ZNTE60T",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-CPA-ZNTE60T-squashfs-cfe.bin"
-      ]
-    },
-    "Huawei EchoLife HG556a A": {
-      "id": "HG556a-A",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-HG556a-A-squashfs-cfe.bin"
-      ]
-    },
-    "D-Link DSL-2740B C3": {
-      "id": "DSL274XB-C3",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL274XB-C3-squashfs-cfe.bin"
-      ]
-    },
-    "D-Link DSL-2741B C3": {
-      "id": "DSL274XB-C3",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-DSL274XB-C3-squashfs-cfe.bin"
-      ]
-    },
-    "NETGEAR EVG2000": {
-      "id": "EVG2000",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-EVG2000-squashfs-factory.chk",
-        "openwrt-brcm63xx-smp-EVG2000-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Huawei EchoLife HG556a B": {
-      "id": "HG556a-B",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-HG556a-B-squashfs-cfe.bin"
-      ]
-    },
-    "Alcatel RG100A": {
-      "id": "RG100A",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-RG100A-squashfs-cfe.bin"
-      ]
-    },
-    "T-Com Speedport W 303V": {
-      "id": "SPW303V",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-SPW303V-squashfs-factory.bin",
-        "openwrt-brcm63xx-smp-SPW303V-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Generic 96348R": {
-      "id": "96348R-generic",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-96348R-generic-squashfs-cfe.bin"
-      ]
-    },
-    "Huawei EchoLife HG655b": {
-      "id": "HG655b",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-HG655b-squashfs-cfe.bin"
-      ]
-    },
-    "Huawei EchoLife HG556a C": {
-      "id": "HG556a-C",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-HG556a-C-squashfs-cfe.bin"
-      ]
-    },
-    "Sagemcom F@st 2704N": {
-      "id": "FAST2704N",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-FAST2704N-squashfs-cfe.bin"
-      ]
-    },
-    "Sagemcom F@st 2704 V2": {
-      "id": "FAST2704V2",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-FAST2704V2-squashfs-cfe.bin"
-      ]
-    },
-    "Tecom GW6000": {
-      "id": "GW6000",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-GW6000-squashfs-cfe.bin"
-      ]
-    },
-    "SFR Neufbox4 Foxconn": {
-      "id": "NEUFBOX4-FXC",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-NEUFBOX4-FXC-squashfs-cfe.bin"
-      ]
-    },
-    "ADB P.DG A4001N1": {
-      "id": "A4001N1",
-      "target": "brcm63xx/smp",
-      "images": [
-        "openwrt-brcm63xx-smp-A4001N1-squashfs-cfe.bin",
-        "openwrt-brcm63xx-smp-A4001N1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "LeMaker Banana Pi R64": {
-      "id": "lemaker_bananapi-bpi-r64",
-      "target": "mediatek/mt7622",
-      "images": [
-        "openwrt-mediatek-mt7622-lemaker_bananapi-bpi-r64-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek MTK7622 Lynx rfb1 AP": {
-      "id": "mediatek_mt7622-lynx-rfb1",
-      "target": "mediatek/mt7622",
-      "images": [
-        "openwrt-mediatek-mt7622-mediatek_mt7622-lynx-rfb1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek MTK7622 rfb1 AP": {
-      "id": "mediatek_mt7622-rfb1",
-      "target": "mediatek/mt7622",
-      "images": [
-        "openwrt-mediatek-mt7622-mediatek_mt7622-rfb1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "UniElec U7623-02 eMMC/512MB RAM": {
-      "id": "unielec_u7623-02-emmc-512m",
-      "target": "mediatek/mt7623",
-      "images": [
-        "openwrt-mediatek-mt7623-unielec_u7623-02-emmc-512m-squashfs-sysupgrade-emmc.bin.gz"
-      ]
-    },
-    "LeMaker Banana Pi R2": {
-      "id": "lemaker_bananapi-bpi-r2",
-      "target": "mediatek/mt7623",
-      "images": [
-        "openwrt-mediatek-mt7623-lemaker_bananapi-bpi-r2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek MT7629 Lynx reference board": {
-      "id": "mediatek_mt7629-lynx-rfb",
-      "target": "mediatek/mt7629",
-      "images": [
-        "openwrt-mediatek-mt7629-mediatek_mt7629-lynx-rfb-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Microchip SAMA5D3 Xplained": {
-      "id": "at91-sama5d3_xplained",
-      "target": "at91/sama5",
-      "images": [
-        "openwrt-at91-sama5-at91-sama5d3_xplained-ubifs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d3_xplained-ubifs-zImage",
-        "openwrt-at91-sama5-at91-sama5d3_xplained-squashfs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d3_xplained-squashfs-zImage",
-        "openwrt-at91-sama5-at91-sama5d3_xplained-ext4-sdcard.img.gz"
-      ]
-    },
-    "Microchip SAMA5D2 PTC Ek": {
-      "id": "at91-sama5d2_ptc_ek",
-      "target": "at91/sama5",
-      "images": [
-        "openwrt-at91-sama5-at91-sama5d2_ptc_ek-ubifs-zImage",
-        "openwrt-at91-sama5-at91-sama5d2_ptc_ek-squashfs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d2_ptc_ek-ubifs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d2_ptc_ek-ext4-sdcard.img.gz"
-      ]
-    },
-    "Microchip SAMA5D27 SOM1 Ek": {
-      "id": "at91-sama5d27_som1_ek",
-      "target": "at91/sama5",
-      "images": [
-        "openwrt-at91-sama5-at91-sama5d27_som1_ek-ubifs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d27_som1_ek-ext4-sdcard.img.gz",
-        "openwrt-at91-sama5-at91-sama5d27_som1_ek-squashfs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d27_som1_ek-squashfs-zImage"
-      ]
-    },
-    "Microchip SAMA5D2 Xplained": {
-      "id": "at91-sama5d2_xplained",
-      "target": "at91/sama5",
-      "images": [
-        "openwrt-at91-sama5-at91-sama5d2_xplained-ubifs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d2_xplained-ubifs-zImage",
-        "openwrt-at91-sama5-at91-sama5d2_xplained-ext4-sdcard.img.gz",
-        "openwrt-at91-sama5-at91-sama5d2_xplained-squashfs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d2_xplained-squashfs-zImage"
-      ]
-    },
-    "Microchip SAMA5D4 Xplained": {
-      "id": "at91-sama5d4_xplained",
-      "target": "at91/sama5",
-      "images": [
-        "openwrt-at91-sama5-at91-sama5d4_xplained-ubifs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d4_xplained-ubifs-zImage",
-        "openwrt-at91-sama5-at91-sama5d4_xplained-squashfs-root.ubi",
-        "openwrt-at91-sama5-at91-sama5d4_xplained-squashfs-zImage",
-        "openwrt-at91-sama5-at91-sama5d4_xplained-ext4-sdcard.img.gz"
-      ]
-    },
-    "Calao TNYA9263": {
-      "id": "tny_a9263",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-tny_a9263-ubifs-factory.bin",
-        "openwrt-at91-sam9x-tny_a9263-squashfs-factory.bin"
-      ]
-    },
-    "Atmel AT91SAM9G20-EK 2MMC": {
-      "id": "at91sam9g20ek_2mmc",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9g20ek_2mmc-squashfs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9g20ek_2mmc-ubifs-root.ubi"
-      ]
-    },
-    "Atmel AT91SAM9X25-EK": {
-      "id": "at91sam9x25ek",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9x25ek-ubifs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9x25ek-ubifs-zImage",
-        "openwrt-at91-sam9x-at91sam9x25ek-ext4-sdcard.img.gz",
-        "openwrt-at91-sam9x-at91sam9x25ek-squashfs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9x25ek-squashfs-zImage"
-      ]
-    },
-    "egnite Ethernut 5": {
-      "id": "ethernut5",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-ethernut5-ubifs-root.ubi",
-        "openwrt-at91-sam9x-ethernut5-squashfs-root.ubi"
-      ]
-    },
-    "Calao TNYA9G20": {
-      "id": "tny_a9g20",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-tny_a9g20-ubifs-factory.bin",
-        "openwrt-at91-sam9x-tny_a9g20-squashfs-factory.bin"
-      ]
-    },
-    "Atmel AT91SAM9G15-EK": {
-      "id": "at91sam9g15ek",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9g15ek-ubifs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9g15ek-squashfs-root.ubi"
-      ]
-    },
-    "Calao USBA9260": {
-      "id": "usb_a9260",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-usb_a9260-ubifs-factory.bin",
-        "openwrt-at91-sam9x-usb_a9260-squashfs-factory.bin"
-      ]
-    },
-    "Atmel AT91SAM9X35-EK": {
-      "id": "at91sam9x35ek",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9x35ek-ubifs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9x35ek-ubifs-zImage",
-        "openwrt-at91-sam9x-at91sam9x35ek-ext4-sdcard.img.gz",
-        "openwrt-at91-sam9x-at91sam9x35ek-squashfs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9x35ek-squashfs-zImage"
-      ]
-    },
-    "Calao USBA9263": {
-      "id": "usb_a9263",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-usb_a9263-ubifs-factory.bin",
-        "openwrt-at91-sam9x-usb_a9263-squashfs-factory.bin"
-      ]
-    },
-    "Atmel AT91SAM9G25-EK": {
-      "id": "at91sam9g25ek",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9g25ek-ubifs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9g25ek-squashfs-root.ubi"
-      ]
-    },
-    "Atmel AT91SAM9M10G45-EK": {
-      "id": "at91sam9m10g45ek",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9m10g45ek-ubifs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9m10g45ek-squashfs-root.ubi"
-      ]
-    },
-    "Atmel AT91SAM9G35-EK": {
-      "id": "at91sam9g35ek",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9g35ek-ubifs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9g35ek-squashfs-root.ubi"
-      ]
-    },
-    "Calao USBA9G20": {
-      "id": "usb_a9g20",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-usb_a9g20-ubifs-factory.bin",
-        "openwrt-at91-sam9x-usb_a9g20-squashfs-factory.bin"
-      ]
-    },
-    "Atmel AT91SAM9G20-EK": {
-      "id": "at91sam9g20ek",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9g20ek-ubifs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9g20ek-ubifs-zImage",
-        "openwrt-at91-sam9x-at91sam9g20ek-squashfs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9g20ek-squashfs-zImage"
-      ]
-    },
-    "Calao TNYA9260": {
-      "id": "tny_a9260",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-tny_a9260-ubifs-factory.bin",
-        "openwrt-at91-sam9x-tny_a9260-squashfs-factory.bin"
-      ]
-    },
-    "Atmel AT91SAM9263-EK": {
-      "id": "at91sam9263ek",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-at91sam9263ek-ubifs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9263ek-ubifs-zImage",
-        "openwrt-at91-sam9x-at91sam9263ek-squashfs-root.ubi",
-        "openwrt-at91-sam9x-at91sam9263ek-squashfs-zImage"
-      ]
-    },
-    "Laird WB45N": {
-      "id": "wb45n",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-wb45n-ubifs-root.ubi",
-        "openwrt-at91-sam9x-wb45n-squashfs-root.ubi"
-      ]
-    },
-    "CalAmp LMU5000": {
-      "id": "lmu5000",
-      "target": "at91/sam9x",
-      "images": [
-        "openwrt-at91-sam9x-lmu5000-squashfs-factory.bin",
-        "openwrt-at91-sam9x-lmu5000-ubifs-factory.bin"
-      ]
-    },
-    "Olimex A13-OLinuXino": {
-      "id": "olimex_a13-olinuxino",
-      "target": "sunxi/cortexa8",
-      "images": [
-        "openwrt-sunxi-cortexa8-olimex_a13-olinuxino-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa8-olimex_a13-olinuxino-ext4-sdcard.img.gz"
-      ]
-    },
-    "HAOYU Electronics MarsBoard A10": {
-      "id": "marsboard_a10-marsboard",
-      "target": "sunxi/cortexa8",
-      "images": [
-        "openwrt-sunxi-cortexa8-marsboard_a10-marsboard-ext4-sdcard.img.gz",
-        "openwrt-sunxi-cortexa8-marsboard_a10-marsboard-squashfs-sdcard.img.gz"
-      ]
-    },
-    "LinkSprite pcDuino": {
-      "id": "linksprite_a10-pcduino",
-      "target": "sunxi/cortexa8",
-      "images": [
-        "openwrt-sunxi-cortexa8-linksprite_a10-pcduino-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa8-linksprite_a10-pcduino-ext4-sdcard.img.gz"
-      ]
-    },
-    "Olimex A13-SOM": {
-      "id": "olimex_a13-olimex-som",
-      "target": "sunxi/cortexa8",
-      "images": [
-        "openwrt-sunxi-cortexa8-olimex_a13-olimex-som-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa8-olimex_a13-olimex-som-ext4-sdcard.img.gz"
-      ]
-    },
-    "Cubietech Cubieboard": {
-      "id": "cubietech_a10-cubieboard",
-      "target": "sunxi/cortexa8",
-      "images": [
-        "openwrt-sunxi-cortexa8-cubietech_a10-cubieboard-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa8-cubietech_a10-cubieboard-ext4-sdcard.img.gz"
-      ]
-    },
-    "Olimex A10-OLinuXino-LIME": {
-      "id": "olimex_a10-olinuxino-lime",
-      "target": "sunxi/cortexa8",
-      "images": [
-        "openwrt-sunxi-cortexa8-olimex_a10-olinuxino-lime-ext4-sdcard.img.gz",
-        "openwrt-sunxi-cortexa8-olimex_a10-olinuxino-lime-squashfs-sdcard.img.gz"
-      ]
-    },
-    "LeMaker Banana Pi": {
-      "id": "lemaker_bananapi",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-lemaker_bananapi-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-lemaker_bananapi-ext4-sdcard.img.gz"
-      ]
-    },
-    "Mele M9": {
-      "id": "mele_m9",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-mele_m9-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-mele_m9-ext4-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi PC Plus": {
-      "id": "xunlong_orangepi-pc-plus",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-pc-plus-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-pc-plus-ext4-sdcard.img.gz"
-      ]
-    },
-    "Cubietech Cubieboard2": {
-      "id": "cubietech_cubieboard2",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-cubietech_cubieboard2-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-cubietech_cubieboard2-ext4-sdcard.img.gz"
-      ]
-    },
-    "LeMaker Banana Pro": {
-      "id": "lemaker_bananapro",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-lemaker_bananapro-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-lemaker_bananapro-ext4-sdcard.img.gz"
-      ]
-    },
-    "FriendlyARM NanoPi NEO": {
-      "id": "friendlyarm_nanopi-neo",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-friendlyarm_nanopi-neo-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-friendlyarm_nanopi-neo-ext4-sdcard.img.gz"
-      ]
-    },
-    "Cubietech Cubietruck": {
-      "id": "cubietech_cubietruck",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-cubietech_cubietruck-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-cubietech_cubietruck-ext4-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi One": {
-      "id": "xunlong_orangepi-one",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-one-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-one-ext4-sdcard.img.gz"
-      ]
-    },
-    "Lamobo Lamobo R1": {
-      "id": "lamobo_lamobo-r1",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-lamobo_lamobo-r1-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-lamobo_lamobo-r1-ext4-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi R1": {
-      "id": "xunlong_orangepi-r1",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-r1-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-r1-ext4-sdcard.img.gz"
-      ]
-    },
-    "FriendlyARM NanoPi M1 Plus": {
-      "id": "friendlyarm_nanopi-m1-plus",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-friendlyarm_nanopi-m1-plus-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-friendlyarm_nanopi-m1-plus-ext4-sdcard.img.gz"
-      ]
-    },
-    "Olimex A20-OLinuXino-LIME2": {
-      "id": "olimex_a20-olinuxino-lime2",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime2-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime2-ext4-sdcard.img.gz"
-      ]
-    },
-    "LinkSprite pcDuino3": {
-      "id": "linksprite_pcduino3",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-linksprite_pcduino3-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-linksprite_pcduino3-ext4-sdcard.img.gz"
-      ]
-    },
-    "Sinovoip Banana Pi M2+": {
-      "id": "sinovoip_bananapi-m2-plus",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-sinovoip_bananapi-m2-plus-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-sinovoip_bananapi-m2-plus-ext4-sdcard.img.gz"
-      ]
-    },
-    "Olimex A20-OLinuXino-MICRO": {
-      "id": "olimex_a20-olinuxino-micro",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-micro-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-micro-ext4-sdcard.img.gz"
-      ]
-    },
-    "FriendlyARM NanoPi NEO Air": {
-      "id": "friendlyarm_nanopi-neo-air",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-friendlyarm_nanopi-neo-air-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-friendlyarm_nanopi-neo-air-ext4-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi Zero": {
-      "id": "xunlong_orangepi-zero",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-zero-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-zero-ext4-sdcard.img.gz"
-      ]
-    },
-    "Olimex A20-OLinuXino-LIME": {
-      "id": "olimex_a20-olinuxino-lime",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime-ext4-sdcard.img.gz"
-      ]
-    },
-    "LeMaker Banana Pi M2 Ultra": {
-      "id": "lemaker_bananapi-m2-ultra",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-lemaker_bananapi-m2-ultra-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-lemaker_bananapi-m2-ultra-ext4-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi 2": {
-      "id": "xunlong_orangepi-2",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-2-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-2-ext4-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi Plus": {
-      "id": "xunlong_orangepi-plus",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-plus-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-plus-ext4-sdcard.img.gz"
-      ]
-    },
-    "Olimex A20-OLinuXino-LIME2 eMMC": {
-      "id": "olimex_a20-olinuxino-lime2-emmc",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime2-emmc-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime2-emmc-ext4-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi PC": {
-      "id": "xunlong_orangepi-pc",
-      "target": "sunxi/cortexa7",
-      "images": [
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-pc-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa7-xunlong_orangepi-pc-ext4-sdcard.img.gz"
-      ]
-    },
-    "Pine64 SoPine": {
-      "id": "pine64_sopine-baseboard",
-      "target": "sunxi/cortexa53",
-      "images": [
-        "openwrt-sunxi-cortexa53-pine64_sopine-baseboard-ext4-sdcard.img.gz",
-        "openwrt-sunxi-cortexa53-pine64_sopine-baseboard-squashfs-sdcard.img.gz"
-      ]
-    },
-    "FriendlyARM NanoPi NEO2": {
-      "id": "friendlyarm_nanopi-neo2",
-      "target": "sunxi/cortexa53",
-      "images": [
-        "openwrt-sunxi-cortexa53-friendlyarm_nanopi-neo2-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa53-friendlyarm_nanopi-neo2-ext4-sdcard.img.gz"
-      ]
-    },
-    "Pine64 Pine64+": {
-      "id": "pine64_pine64-plus",
-      "target": "sunxi/cortexa53",
-      "images": [
-        "openwrt-sunxi-cortexa53-pine64_pine64-plus-ext4-sdcard.img.gz",
-        "openwrt-sunxi-cortexa53-pine64_pine64-plus-squashfs-sdcard.img.gz"
-      ]
-    },
-    "FriendlyARM NanoPi NEO Plus2": {
-      "id": "friendlyarm_nanopi-neo-plus2",
-      "target": "sunxi/cortexa53",
-      "images": [
-        "openwrt-sunxi-cortexa53-friendlyarm_nanopi-neo-plus2-squashfs-sdcard.img.gz",
-        "openwrt-sunxi-cortexa53-friendlyarm_nanopi-neo-plus2-ext4-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi Zero Plus": {
-      "id": "xunlong_orangepi-zero-plus",
-      "target": "sunxi/cortexa53",
-      "images": [
-        "openwrt-sunxi-cortexa53-xunlong_orangepi-zero-plus-ext4-sdcard.img.gz",
-        "openwrt-sunxi-cortexa53-xunlong_orangepi-zero-plus-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Xunlong Orange Pi PC 2": {
-      "id": "xunlong_orangepi-pc2",
-      "target": "sunxi/cortexa53",
-      "images": [
-        "openwrt-sunxi-cortexa53-xunlong_orangepi-pc2-ext4-sdcard.img.gz",
-        "openwrt-sunxi-cortexa53-xunlong_orangepi-pc2-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Imagination Technologies Creator Ci40 (VL-62899)": {
-      "id": "marduk",
-      "target": "pistachio",
-      "images": [
-        "openwrt-pistachio-marduk-squashfs-sysupgrade.tar",
-        "openwrt-pistachio-marduk-squashfs-factory.ubi"
-      ]
-    },
-    "Imagination Technologies Marduk board": {
-      "id": "marduk",
-      "target": "pistachio",
-      "images": [
-        "openwrt-pistachio-marduk-squashfs-sysupgrade.tar",
-        "openwrt-pistachio-marduk-squashfs-factory.ubi"
-      ]
-    },
-    "Cisco Meraki MX60/MX60W": {
-      "id": "meraki_mx60",
-      "target": "apm821xx/nand",
-      "images": [
-        "openwrt-apm821xx-nand-meraki_mx60-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR Centria N900 WNDR4700/WNDR4720": {
-      "id": "netgear_wndr4700",
-      "target": "apm821xx/nand",
-      "images": [
-        "openwrt-apm821xx-nand-netgear_wndr4700-squashfs-sysupgrade.bin",
-        "openwrt-apm821xx-nand-netgear_wndr4700-squashfs-factory.img"
-      ]
-    },
-    "NETGEAR WNDAP620 (Premium Wireless-N)": {
-      "id": "netgear_wndap620",
-      "target": "apm821xx/nand",
-      "images": [
-        "openwrt-apm821xx-nand-netgear_wndap620-squashfs-sysupgrade.bin",
-        "openwrt-apm821xx-nand-netgear_wndap620-squashfs-factory.img"
-      ]
-    },
-    "NETGEAR WNDAP660 (Dual Radio Dual Band Wireless-N)": {
-      "id": "netgear_wndap660",
-      "target": "apm821xx/nand",
-      "images": [
-        "openwrt-apm821xx-nand-netgear_wndap660-squashfs-sysupgrade.bin",
-        "openwrt-apm821xx-nand-netgear_wndap660-squashfs-factory.img"
-      ]
-    },
-    "Cisco Meraki MR24": {
-      "id": "meraki_mr24",
-      "target": "apm821xx/nand",
-      "images": [
-        "openwrt-apm821xx-nand-meraki_mr24-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Western Digital My Book Live Series (Single + Duo)": {
-      "id": "wd_mybooklive",
-      "target": "apm821xx/sata",
-      "images": [
-        "openwrt-apm821xx-sata-wd_mybooklive-ext4-factory.img.gz",
-        "openwrt-apm821xx-sata-wd_mybooklive-ext4-sysupgrade.img.gz",
-        "openwrt-apm821xx-sata-wd_mybooklive-squashfs-factory.img.gz",
-        "openwrt-apm821xx-sata-wd_mybooklive-squashfs-sysupgrade.img.gz"
-      ]
-    },
-    "Linksys WRT310N v1": {
-      "id": "linksys-wrt310n-v1",
-      "target": "brcm47xx/generic",
-      "images": [
-        "openwrt-brcm47xx-generic-linksys-wrt310n-v1-squashfs.bin"
-      ]
-    },
-    "Linksys WRT300N v1.1": {
-      "id": "linksys-wrt300n-v1.1",
-      "target": "brcm47xx/generic",
-      "images": [
-        "openwrt-brcm47xx-generic-linksys-wrt300n-v1.1-squashfs.bin"
-      ]
-    },
-    "Linksys WRT610N v1": {
-      "id": "linksys-wrt610n-v1",
-      "target": "brcm47xx/generic",
-      "images": [
-        "openwrt-brcm47xx-generic-linksys-wrt610n-v1-squashfs.bin"
-      ]
-    },
-    "Linksys WRT350N v1": {
-      "id": "linksys-wrt350n-v1",
-      "target": "brcm47xx/generic",
-      "images": [
-        "openwrt-brcm47xx-generic-linksys-wrt350n-v1-squashfs.bin"
-      ]
-    },
-    "Image with LZMA loader and LZMA compressed kernel": {
-      "id": "standard",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-standard-squashfs.trx"
-      ]
-    },
-    "Linksys E3000 v1": {
-      "id": "linksys-e3000-v1",
-      "target": "brcm47xx/generic",
-      "images": [
-        "openwrt-brcm47xx-generic-linksys-e3000-v1-squashfs.bin"
-      ]
-    },
-    "Linksys WRT610N v2": {
-      "id": "linksys-wrt610n-v2",
-      "target": "brcm47xx/generic",
-      "images": [
-        "openwrt-brcm47xx-generic-linksys-wrt610n-v2-squashfs.bin"
-      ]
-    },
-    "ASUS WL-520gU": {
-      "id": "asus-wl-520gu",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-520gu-squashfs.trx"
-      ]
-    },
-    "Motorola WA840G": {
-      "id": "motorola-wa840g",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-motorola-wa840g-squashfs.bin"
-      ]
-    },
-    "ASUS WL-320gP": {
-      "id": "asus-wl-320gp",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-320gp-squashfs.trx"
-      ]
-    },
-    "ASUS WL-550gE": {
-      "id": "asus-wl-550ge",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-550ge-squashfs.trx"
-      ]
-    },
-    "Edimax PS-1208MFg": {
-      "id": "edimax-ps1208-mfg",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-edimax-ps1208-mfg-squashfs.bin"
-      ]
-    },
-    "NETGEAR WNDR3300 v1": {
-      "id": "netgear-wndr3300-v1",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-netgear-wndr3300-v1-squashfs.chk"
-      ]
-    },
-    "Linksys WRT160N v1": {
-      "id": "linksys-wrt160n-v1",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt160n-v1-squashfs.bin"
-      ]
-    },
-    "ASUS WL-HDD25": {
-      "id": "asus-wl-hdd25",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-hdd25-squashfs.trx"
-      ]
-    },
-    "Huawei E970": {
-      "id": "huawei-e970",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-huawei-e970-squashfs.bin"
-      ]
-    },
-    "ASUS WL-500gP v2": {
-      "id": "asus-wl-500gp-v2",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-500gp-v2-squashfs.trx"
-      ]
-    },
-    "ASUS WL-500W": {
-      "id": "asus-wl-500w",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-500w-squashfs.trx"
-      ]
-    },
-    "NETGEAR WGR614 v8": {
-      "id": "netgear-wgr614-v8",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-netgear-wgr614-v8-squashfs.chk"
-      ]
-    },
-    "Motorola WR850G": {
-      "id": "motorola-wr850g",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-motorola-wr850g-squashfs.bin"
-      ]
-    },
-    "D-Link DWL-3150": {
-      "id": "dlink-dwl-3150",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-dlink-dwl-3150-squashfs.bin"
-      ]
-    },
-    "Linksys WRT54G3G-EM": {
-      "id": "linksys-wrt54g3g-em",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt54g3g-em-squashfs.bin"
-      ]
-    },
-    "ASUS WL-300g": {
-      "id": "asus-wl-300g",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-300g-squashfs.trx"
-      ]
-    },
-    "Linksys WRT54G3G": {
-      "id": "linksys-wrt54g3g",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt54g3g-squashfs.bin"
-      ]
-    },
-    "Motorola WE800G": {
-      "id": "motorola-we800g",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-motorola-we800g-squashfs.bin"
-      ]
-    },
-    "Linksys WRTSL54GS": {
-      "id": "linksys-wrtsl54gs",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrtsl54gs-squashfs.bin"
-      ]
-    },
-    "NETGEAR WNR834B v2": {
-      "id": "netgear-wnr834b-v2",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-netgear-wnr834b-v2-squashfs.chk"
-      ]
-    },
-    "Linksys WRT54G": {
-      "id": "linksys-wrt54g",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt54g-squashfs.bin"
-      ]
-    },
-    "NETGEAR WGT634U": {
-      "id": "netgear-wgt634u",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-netgear-wgt634u-squashfs.bin"
-      ]
-    },
-    "ASUS WL-500g Deluxe": {
-      "id": "asus-wl-500gd",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-500gd-squashfs.trx"
-      ]
-    },
-    "Linksys WRT150N": {
-      "id": "linksys-wrt150n",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt150n-squashfs.bin"
-      ]
-    },
-    "Image with gzipped kernel": {
-      "id": "standard-noloader-gz",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-standard-noloader-gz-squashfs.trx"
-      ]
-    },
-    "ASUS WL-330gE": {
-      "id": "asus-wl-330ge",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-330ge-squashfs.trx"
-      ]
-    },
-    "Linksys WRT54GS v1/v2/v3": {
-      "id": "linksys-wrt54gs",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt54gs-squashfs.bin"
-      ]
-    },
-    "Linksys WRT54G-TM v1": {
-      "id": "linksys-wrt54gs",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt54gs-squashfs.bin"
-      ]
-    },
-    "ASUS WL-500gP v1": {
-      "id": "asus-wl-500gp-v1",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-asus-wl-500gp-v1-squashfs.trx"
-      ]
-    },
-    "US Robotics USR5461": {
-      "id": "usrobotics-usr5461",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-usrobotics-usr5461-squashfs.bin"
-      ]
-    },
-    "Linksys WRT300N v1": {
-      "id": "linksys-wrt300n-v1",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt300n-v1-squashfs.bin",
-        "openwrt-brcm47xx-legacy-linksys-wrt300n-v1-squashfs.trx"
-      ]
-    },
-    "Linksys WRT54G3GV2-VF": {
-      "id": "linksys-wrt54g3gv2-vf",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt54g3gv2-vf-squashfs.noheader.bin",
-        "openwrt-brcm47xx-legacy-linksys-wrt54g3gv2-vf-squashfs.bin"
-      ]
-    },
-    "Linksys WRT54GS v4": {
-      "id": "linksys-wrt54gs-v4",
-      "target": "brcm47xx/legacy",
-      "images": [
-        "openwrt-brcm47xx-legacy-linksys-wrt54gs-v4-squashfs.bin"
-      ]
-    },
-    "ASUS RT-N12 D1": {
-      "id": "asus-rt-n12-d1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n12-d1-squashfs.trx"
-      ]
-    },
-    "Linksys E2500 v2": {
-      "id": "linksys-e2500-v2",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e2500-v2-squashfs.bin"
-      ]
-    },
-    "Linksys E1200 v1": {
-      "id": "linksys-e1200-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e1200-v1-squashfs.bin"
-      ]
-    },
-    "ASUS RT-N12HP": {
-      "id": "asus-rt-n12hp",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n12hp-squashfs.trx"
-      ]
-    },
-    "Linksys E1000 v1/v2/v2.1": {
-      "id": "linksys-e1000",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e1000-squashfs.bin"
-      ]
-    },
-    "NETGEAR WNDR4000 v1": {
-      "id": "netgear-wndr4000",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wndr4000-squashfs.chk"
-      ]
-    },
-    "NETGEAR WNR3500L v1 (ROW)": {
-      "id": "netgear-wnr3500l-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wnr3500l-v1-squashfs.chk"
-      ]
-    },
-    "NETGEAR WNR3500L v2": {
-      "id": "netgear-wnr3500l-v2",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wnr3500l-v2-squashfs.chk"
-      ]
-    },
-    "NETGEAR WNR1000 v3": {
-      "id": "netgear-wnr1000-v3",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wnr1000-v3-squashfs.chk"
-      ]
-    },
-    "Linksys E2500 v2.1": {
-      "id": "linksys-e2500-v2.1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e2500-v2.1-squashfs.bin"
-      ]
-    },
-    "NETGEAR WN2500RP v1": {
-      "id": "netgear-wn2500rp-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wn2500rp-v1-squashfs.chk"
-      ]
-    },
-    "ASUS RT-AC53U": {
-      "id": "asus-rt-ac53u",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-ac53u-squashfs.trx"
-      ]
-    },
-    "Linksys E2000 v1": {
-      "id": "linksys-e2000-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e2000-v1-squashfs.bin"
-      ]
-    },
-    "ASUS RT-N12 C1": {
-      "id": "asus-rt-n12-c1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n12-c1-squashfs.trx"
-      ]
-    },
-    "ASUS RT-N53": {
-      "id": "asus-rt-n53",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n53-squashfs.trx"
-      ]
-    },
-    "NETGEAR WNDR3700 v3": {
-      "id": "netgear-wndr3700-v3",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wndr3700-v3-squashfs.chk"
-      ]
-    },
-    "Linksys E1500 v1": {
-      "id": "linksys-e1500-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e1500-v1-squashfs.bin"
-      ]
-    },
-    "ASUS RT-N10U B": {
-      "id": "asus-rt-n10u-b",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n10u-b-squashfs.trx"
-      ]
-    },
-    "ASUS RT-N66W": {
-      "id": "asus-rt-n66w",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n66w-squashfs.trx"
-      ]
-    },
-    "NETGEAR WGR614 v10 (NA)": {
-      "id": "netgear-wgr614-v10-na",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wgr614-v10-na-squashfs.chk"
-      ]
-    },
-    "NETGEAR WN3000RP": {
-      "id": "netgear-wn3000rp",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wn3000rp-squashfs.chk"
-      ]
-    },
-    "ASUS RT-N10P v2": {
-      "id": "asus-rt-n10p-v2",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n10p-v2-squashfs.trx"
-      ]
-    },
-    "ASUS RT-N15U": {
-      "id": "asus-rt-n15u",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n15u-squashfs.trx"
-      ]
-    },
-    "ASUS RT-N10P v1": {
-      "id": "asus-rt-n10p",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n10p-squashfs.trx"
-      ]
-    },
-    "NETGEAR WNDR3400 v3": {
-      "id": "netgear-wndr3400-v3",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wndr3400-v3-squashfs.chk"
-      ]
-    },
-    "NETGEAR WNR2000 v2": {
-      "id": "netgear-wnr2000v2",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wnr2000v2-squashfs.chk"
-      ]
-    },
-    "ASUS RT-N12 A1": {
-      "id": "asus-rt-n12",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n12-squashfs.trx"
-      ]
-    },
-    "NETGEAR WGR614 v10": {
-      "id": "netgear-wgr614-v10",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wgr614-v10-squashfs.chk"
-      ]
-    },
-    "Image with LZMA compressed kernel matching CFE decompressor": {
-      "id": "standard-noloader-nodictionarylzma",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-standard-noloader-nodictionarylzma-squashfs.trx"
-      ]
-    },
-    "Linksys E4200 v1": {
-      "id": "linksys-e4200-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e4200-v1-squashfs.bin"
-      ]
-    },
-    "ASUS RT-N10U A": {
-      "id": "asus-rt-n10u",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n10u-squashfs.trx"
-      ]
-    },
-    "Linksys E2500 v1": {
-      "id": "linksys-e2500-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e2500-v1-squashfs.bin"
-      ]
-    },
-    "ASUS RT-N12 B1": {
-      "id": "asus-rt-n12-b1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n12-b1-squashfs.trx"
-      ]
-    },
-    "ASUS RT-N66U": {
-      "id": "asus-rt-n66u",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n66u-squashfs.trx"
-      ]
-    },
-    "NETGEAR WNDR3400 v1": {
-      "id": "netgear-wndr3400-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wndr3400-v1-squashfs.chk"
-      ]
-    },
-    "ASUS RT-N10": {
-      "id": "asus-rt-n10",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n10-squashfs.trx"
-      ]
-    },
-    "NETGEAR WNDR3400 v2": {
-      "id": "netgear-wndr3400-v2",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wndr3400-v2-squashfs.chk"
-      ]
-    },
-    "Linksys WRT310N v2": {
-      "id": "linksys-wrt310n-v2",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-wrt310n-v2-squashfs.bin"
-      ]
-    },
-    "NETGEAR WNR3500 v2": {
-      "id": "netgear-wnr3500-v2",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wnr3500-v2-squashfs.chk"
-      ]
-    },
-    "Linksys WRT160N v3": {
-      "id": "linksys-wrt160n-v3",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-wrt160n-v3-squashfs.bin"
-      ]
-    },
-    "ASUS RT-N16": {
-      "id": "asus-rt-n16",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n16-squashfs.trx"
-      ]
-    },
-    "Linksys E3200 v1": {
-      "id": "linksys-e3200-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e3200-v1-squashfs.bin"
-      ]
-    },
-    "Linksys E2500 v3": {
-      "id": "linksys-e2500-v3",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e2500-v3-squashfs.bin"
-      ]
-    },
-    "NETGEAR WNR3500L v1 (NA)": {
-      "id": "netgear-wnr3500l-v1-na",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-netgear-wnr3500l-v1-na-squashfs.chk"
-      ]
-    },
-    "Linksys E1550 v1": {
-      "id": "linksys-e1550-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e1550-v1-squashfs.bin"
-      ]
-    },
-    "ASUS RT-N14UHP": {
-      "id": "asus-rt-n14uhp",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-asus-rt-n14uhp-squashfs.trx"
-      ]
-    },
-    "Linksys WRT320N v1": {
-      "id": "linksys-wrt320n-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-wrt320n-v1-squashfs.bin"
-      ]
-    },
-    "Linksys E900 v1": {
-      "id": "linksys-e900-v1",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e900-v1-squashfs.bin"
-      ]
-    },
-    "Linksys E1200 v2": {
-      "id": "linksys-e1200-v2",
-      "target": "brcm47xx/mips74k",
-      "images": [
-        "openwrt-brcm47xx-mips74k-linksys-e1200-v2-squashfs.bin"
-      ]
-    },
-    "Sophos RED 15w Rev.1": {
-      "id": "sophos_red-15w-rev1",
-      "target": "mpc85xx/generic",
-      "images": [
-        "openwrt-mpc85xx-generic-sophos_red-15w-rev1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WDR4900 v1": {
-      "id": "tplink_tl-wdr4900-v1",
-      "target": "mpc85xx/generic",
-      "images": [
-        "openwrt-mpc85xx-generic-tplink_tl-wdr4900-v1-squashfs-sysupgrade.bin",
-        "openwrt-mpc85xx-generic-tplink_tl-wdr4900-v1-squashfs-factory.bin"
-      ]
-    },
-    "Freescale P2020RDB": {
-      "id": "freescale_p2020rdb",
-      "target": "mpc85xx/p2020",
-      "images": [
-        "openwrt-mpc85xx-p2020-freescale_p2020rdb-squashfs-sysupgrade.bin"
-      ]
-    },
-    "OCEDO Panda": {
-      "id": "ocedo_panda",
-      "target": "mpc85xx/p1020",
-      "images": [
-        "openwrt-mpc85xx-p1020-ocedo_panda-squashfs-fdt.bin",
-        "openwrt-mpc85xx-p1020-ocedo_panda-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Aerohive HiveAP-330": {
-      "id": "aerohive_hiveap-330",
-      "target": "mpc85xx/p1020",
-      "images": [
-        "openwrt-mpc85xx-p1020-aerohive_hiveap-330-squashfs-fdt.bin",
-        "openwrt-mpc85xx-p1020-aerohive_hiveap-330-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Enterasys WS-AP3710i": {
-      "id": "enterasys_ws-ap3710i",
-      "target": "mpc85xx/p1020",
-      "images": [
-        "openwrt-mpc85xx-p1020-enterasys_ws-ap3710i-squashfs-sysupgrade.bin"
-      ]
-    },
-    "PandaBoard.org OMAP4 TI pandaboard": {
-      "id": "ti_omap4-panda",
-      "target": "omap",
-      "images": [
-        "openwrt-omap-ti_omap4-panda-ext4-sdcard.img.gz",
-        "openwrt-omap-ti_omap4-panda-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Texas Instruments AM335x EVM": {
-      "id": "ti_am335x-evm",
-      "target": "omap",
-      "images": [
-        "openwrt-omap-ti_am335x-evm-ext4-sdcard.img.gz",
-        "openwrt-omap-ti_am335x-evm-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Texas Instruments AM335x BeagleBone Black": {
-      "id": "ti_am335x-bone-black",
-      "target": "omap",
-      "images": [
-        "openwrt-omap-ti_am335x-bone-black-ext4-sdcard.img.gz",
-        "openwrt-omap-ti_am335x-bone-black-squashfs-sdcard.img.gz"
-      ]
-    },
-    "BeagleBoard.org OMAP3 TI beagleboard": {
-      "id": "ti_omap3-beagle",
-      "target": "omap",
-      "images": [
-        "openwrt-omap-ti_omap3-beagle-ext4-sdcard.img.gz",
-        "openwrt-omap-ti_omap3-beagle-squashfs-sdcard.img.gz"
-      ]
-    },
-    "SolidRun CuBox-i": {
-      "id": "cubox",
-      "target": "imx6",
-      "images": [
-        "openwrt-imx6-cubox-i-squashfs-combined.bin"
-      ]
-    },
-    "Gateworks Ventana family large NAND flash": {
-      "id": "ventana",
-      "target": "imx6",
-      "images": [
-        "openwrt-imx6-ventana-large-squashfs-nand.ubi"
-      ]
-    },
-    "Gateworks Ventana family normal NAND flash": {
-      "id": "ventana",
-      "target": "imx6",
-      "images": [
-        "openwrt-imx6-ventana-squashfs-nand.ubi",
-        "openwrt-imx6-ventana-squashfs-bootfs.tar.gz"
-      ]
-    },
-    "Toradex Apalis family": {
-      "id": "apalis",
-      "target": "imx6",
-      "images": [
-        "openwrt-imx6-apalis-squashfs.sysupgrade.bin",
-        "openwrt-imx6-apalis-squashfs.combined.bin"
-      ]
-    },
-    "Raspberry Pi 2B/3B/3B+/3CM/4B": {
-      "id": "rpi-2",
-      "target": "brcm2708/bcm2709",
-      "images": [
-        "openwrt-brcm2708-bcm2709-rpi-2-ext4-factory.img.gz",
-        "openwrt-brcm2708-bcm2709-rpi-2-ext4-sysupgrade.img.gz",
-        "openwrt-brcm2708-bcm2709-rpi-2-squashfs-factory.img.gz",
-        "openwrt-brcm2708-bcm2709-rpi-2-squashfs-sysupgrade.img.gz"
-      ]
-    },
-    "Raspberry Pi 4B": {
-      "id": "rpi-4",
-      "target": "brcm2708/bcm2711",
-      "images": [
-        "openwrt-brcm2708-bcm2711-rpi-4-squashfs-factory.img.gz",
-        "openwrt-brcm2708-bcm2711-rpi-4-squashfs-sysupgrade.img.gz",
-        "openwrt-brcm2708-bcm2711-rpi-4-ext4-factory.img.gz",
-        "openwrt-brcm2708-bcm2711-rpi-4-ext4-sysupgrade.img.gz"
-      ]
-    },
-    "Raspberry Pi 2B-1.2/3B/3B+/3CM": {
-      "id": "rpi-3",
-      "target": "brcm2708/bcm2710",
-      "images": [
-        "openwrt-brcm2708-bcm2710-rpi-3-squashfs-factory.img.gz",
-        "openwrt-brcm2708-bcm2710-rpi-3-ext4-factory.img.gz",
-        "openwrt-brcm2708-bcm2710-rpi-3-squashfs-sysupgrade.img.gz"
-      ]
-    },
-    "Raspberry Pi B/B+/CM/Zero/ZeroW": {
-      "id": "rpi",
-      "target": "brcm2708/bcm2708",
-      "images": [
-        "openwrt-brcm2708-bcm2708-rpi-ext4-factory.img.gz",
-        "openwrt-brcm2708-bcm2708-rpi-ext4-sysupgrade.img.gz",
-        "openwrt-brcm2708-bcm2708-rpi-squashfs-factory.img.gz",
-        "openwrt-brcm2708-bcm2708-rpi-squashfs-sysupgrade.img.gz"
-      ]
-    },
-    "TP-Link RE650 v1": {
-      "id": "tplink_re650-v1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-tplink_re650-v1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-tplink_re650-v1-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR R6350": {
-      "id": "netgear_r6350",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-netgear_r6350-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-netgear_r6350-squashfs-kernel.bin",
-        "openwrt-ramips-mt7621-netgear_r6350-squashfs-factory.img",
-        "openwrt-ramips-mt7621-netgear_r6350-squashfs-rootfs.bin"
-      ]
-    },
-    "TP-Link RE350 v1": {
-      "id": "tplink_re350-v1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-tplink_re350-v1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-tplink_re350-v1-squashfs-factory.bin"
-      ]
-    },
-    "I-O DATA WNPR2600G": {
-      "id": "iodata_wnpr2600g",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-iodata_wnpr2600g-squashfs-factory.bin"
-      ]
-    },
-    "Edimax Gemini AC2600 RG21S": {
-      "id": "edimax_rg21s",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-edimax_rg21s-squashfs-factory.bin"
-      ]
-    },
-    "WeVO W2914NS v2": {
-      "id": "wevo_w2914ns-v2",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-wevo_w2914ns-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti EdgeRouter X-SFP": {
-      "id": "ubiquiti_edgerouterx-sfp",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-ubiquiti_edgerouterx-sfp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Phicomm K2P": {
-      "id": "phicomm_k2p",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-phicomm_k2p-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Phicomm KE 2P": {
-      "id": "phicomm_k2p",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-phicomm_k2p-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Linksys RE6500": {
-      "id": "linksys_re6500",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-linksys_re6500-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AsiaRF AP7621-NV1": {
-      "id": "asiarf_ap7621-nv1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-asiarf_ap7621-nv1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Xiaomi Mi Router 3 Pro": {
-      "id": "xiaomi_mir3p",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-xiaomi_mir3p-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-xiaomi_mir3p-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR EX6150": {
-      "id": "netgear_ex6150",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-netgear_ex6150-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-netgear_ex6150-squashfs-factory.chk"
-      ]
-    },
-    "D-Link DIR-860L B1": {
-      "id": "dlink_dir-860l-b1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-dlink_dir-860l-b1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-dlink_dir-860l-b1-squashfs-factory.bin"
-      ]
-    },
-    "NETIS WF-2881": {
-      "id": "netis_wf-2881",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-netis_wf-2881-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR R6220": {
-      "id": "netgear_r6220",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-netgear_r6220-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-netgear_r6220-squashfs-kernel.bin",
-        "openwrt-ramips-mt7621-netgear_r6220-squashfs-factory.img",
-        "openwrt-ramips-mt7621-netgear_r6220-squashfs-rootfs.bin"
-      ]
-    },
-    "UniElec U7621-06 64M": {
-      "id": "unielec_u7621-06-64m",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-unielec_u7621-06-64m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "I-O DATA WN-GX300GR": {
-      "id": "iodata_wn-gx300gr",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-iodata_wn-gx300gr-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ASUS RT-AC57U": {
-      "id": "asus_rt-ac57u",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-asus_rt-ac57u-squashfs-sysupgrade.bin"
-      ]
-    },
-    "JCG JHR-AC876M": {
-      "id": "jcg_jhr-ac876m",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-jcg_jhr-ac876m-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-jcg_jhr-ac876m-squashfs-factory.bin"
-      ]
-    },
-    "MikroTik RouterBOARD M33G": {
-      "id": "mikrotik_rbm33g",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-mikrotik_rbm33g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WG3526 32M": {
-      "id": "zbtlink_zbt-wg3526-32m",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-zbtlink_zbt-wg3526-32m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Mediatek AP-MT7621A-V60 EVB": {
-      "id": "mediatek_ap-mt7621a-v60",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-mediatek_ap-mt7621a-v60-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Newifi D2": {
-      "id": "d-team_newifi-d2",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-d-team_newifi-d2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "PandoraBox PBR-M1": {
-      "id": "d-team_pbr-m1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-d-team_pbr-m1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek MT7621 EVB": {
-      "id": "mediatek_mt7621-eval-board",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-mediatek_mt7621-eval-board-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR R6260": {
-      "id": "netgear_r6260",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-netgear_r6260-squashfs-kernel.bin",
-        "openwrt-ramips-mt7621-netgear_r6260-squashfs-factory.img"
-      ]
-    },
-    "YouHua WR1200JS": {
-      "id": "youhua_wr1200js",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-youhua_wr1200js-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Newifi D1": {
-      "id": "lenovo_newifi-d1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-lenovo_newifi-d1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "I-O DATA WN-AX1167GR": {
-      "id": "iodata_wn-ax1167gr",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-iodata_wn-ax1167gr-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ALFA Network Quad-E4G": {
-      "id": "alfa-network_quad-e4g",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-alfa-network_quad-e4g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WG3526 16M": {
-      "id": "zbtlink_zbt-wg3526-16m",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-zbtlink_zbt-wg3526-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "XiaoYu XY-C5": {
-      "id": "xiaoyu_xy-c5",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-xiaoyu_xy-c5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ASUS RT-AC85P": {
-      "id": "asus_rt-ac85p",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-asus_rt-ac85p-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-asus_rt-ac85p-squashfs-factory.bin"
-      ]
-    },
-    "GnuBee Personal Cloud One": {
-      "id": "gnubee_gb-pc1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-gnubee_gb-pc1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TOTOLINK A7000R": {
-      "id": "totolink_a7000r",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-totolink_a7000r-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti EdgeRouter X": {
-      "id": "ubiquiti_edgerouterx",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-ubiquiti_edgerouterx-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AFOUNDRY EW1200": {
-      "id": "afoundry_ew1200",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-afoundry_ew1200-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Planex VR500": {
-      "id": "planex_vr500",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-planex_vr500-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ELECOM WRC-1900GST": {
-      "id": "elecom_wrc-1900gst",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-elecom_wrc-1900gst-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-elecom_wrc-1900gst-squashfs-factory.bin"
-      ]
-    },
-    "ADSLR G7": {
-      "id": "adslr_g7",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-adslr_g7-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Thunder Timecloud": {
-      "id": "thunder_timecloud",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-thunder_timecloud-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MikroTik RouterBOARD RB750G r3": {
-      "id": "mikrotik_rb750gr3",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-mikrotik_rb750gr3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WSR-1166DHP": {
-      "id": "buffalo_wsr-1166dhp",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-buffalo_wsr-1166dhp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WSR-600DHP": {
-      "id": "buffalo_wsr-600dhp",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-buffalo_wsr-600dhp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "CreativeBox v1": {
-      "id": "xzwifi_creativebox-v1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-xzwifi_creativebox-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MQmaker WiTi": {
-      "id": "mqmaker_witi",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-mqmaker_witi-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZIO FREEZIO": {
-      "id": "zio_freezio",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-zio_freezio-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR R6850": {
-      "id": "netgear_r6850",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-netgear_r6850-squashfs-kernel.bin",
-        "openwrt-ramips-mt7621-netgear_r6850-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-netgear_r6850-squashfs-factory.img",
-        "openwrt-ramips-mt7621-netgear_r6850-squashfs-rootfs.bin"
-      ]
-    },
-    "Zbtlink ZBT-WG2626": {
-      "id": "zbtlink_zbt-wg2626",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-zbtlink_zbt-wg2626-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Xiaomi Mi Router 3G": {
-      "id": "xiaomi_mir3g",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-xiaomi_mir3g-squashfs-kernel1.bin",
-        "openwrt-ramips-mt7621-xiaomi_mir3g-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-xiaomi_mir3g-squashfs-rootfs0.bin"
-      ]
-    },
-    "Edimax RA21S": {
-      "id": "edimax_ra21s",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-edimax_ra21s-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-edimax_ra21s-squashfs-factory.bin"
-      ]
-    },
-    "Edimax Gemini RA21S": {
-      "id": "edimax_ra21s",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-edimax_ra21s-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-edimax_ra21s-squashfs-factory.bin"
-      ]
-    },
-    "WeVO 11AC NAS Router": {
-      "id": "wevo_11acnas",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-wevo_11acnas-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MTC Wireless Router WR1201": {
-      "id": "mtc_wr1201",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-mtc_wr1201-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Xiaomi Mi Router 3G v2": {
-      "id": "xiaomi_mir3g-v2",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-xiaomi_mir3g-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Xiaomi Mi Router 4A Gigabit Edition": {
-      "id": "xiaomi_mir3g-v2",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-xiaomi_mir3g-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WE1326": {
-      "id": "zbtlink_zbt-we1326",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-zbtlink_zbt-we1326-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ASUS RT-AC65P": {
-      "id": "asus_rt-ac65p",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-asus_rt-ac65p-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-asus_rt-ac65p-squashfs-factory.bin"
-      ]
-    },
-    "ELECOM WRC-2533GST": {
-      "id": "elecom_wrc-2533gst",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-elecom_wrc-2533gst-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-elecom_wrc-2533gst-squashfs-factory.bin"
-      ]
-    },
-    "ipTIME A6ns-M": {
-      "id": "iptime_a6ns-m",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-iptime_a6ns-m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WE3526": {
-      "id": "zbtlink_zbt-we3526",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-zbtlink_zbt-we3526-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Telco Electronics X1": {
-      "id": "telco-electronics_x1",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-telco-electronics_x1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Youku YK-L2": {
-      "id": "youku_yk-l2",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-youku_yk-l2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Firefly FireWRT": {
-      "id": "firefly_firewrt",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-firefly_firewrt-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MikroTik RouterBOARD M11G": {
-      "id": "mikrotik_rbm11g",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-mikrotik_rbm11g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR WNDR3700 v5": {
-      "id": "netgear_wndr3700-v5",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-netgear_wndr3700-v5-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-netgear_wndr3700-v5-squashfs-factory.img"
-      ]
-    },
-    "ELECOM WRC-1167GHBK2-S": {
-      "id": "elecom_wrc-1167ghbk2-s",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-elecom_wrc-1167ghbk2-s-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7621-elecom_wrc-1167ghbk2-s-squashfs-factory.bin"
-      ]
-    },
-    "AsiaRF AP7621-001": {
-      "id": "asiarf_ap7621-001",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-asiarf_ap7621-001-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ipTIME A8004T": {
-      "id": "iptime_a8004t",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-iptime_a8004t-squashfs-sysupgrade.bin"
-      ]
-    },
-    "STORYLiNK SAP-G3200U3": {
-      "id": "storylink_sap-g3200u3",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-storylink_sap-g3200u3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "SamKnows Whitebox 8": {
-      "id": "samknows_whitebox-v8",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-samknows_whitebox-v8-squashfs-sysupgrade.bin"
-      ]
-    },
-    "UniElec U7621-06 16M": {
-      "id": "unielec_u7621-06-16m",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-unielec_u7621-06-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GnuBee Personal Cloud Two": {
-      "id": "gnubee_gb-pc2",
-      "target": "ramips/mt7621",
-      "images": [
-        "openwrt-ramips-mt7621-gnubee_gb-pc2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Poray IP2202": {
-      "id": "poray_ip2202",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-poray_ip2202-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Aztech HW550-3G": {
-      "id": "aztech_hw550-3g",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-aztech_hw550-3g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Allnet ALL0239-3G": {
-      "id": "aztech_hw550-3g",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-aztech_hw550-3g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Hi-Link HLK-RM04": {
-      "id": "hilink_hlk-rm04",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-hilink_hlk-rm04-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-hilink_hlk-rm04-squashfs-factory.bin"
-      ]
-    },
-    "MoFi Network MOFI3500-3GN": {
-      "id": "mofinetwork_mofi3500-3gn",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-mofinetwork_mofi3500-3gn-squashfs-sysupgrade.bin"
-      ]
-    },
-    "JCG JHR-N926R": {
-      "id": "jcg_jhr-n926r",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-jcg_jhr-n926r-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-jcg_jhr-n926r-squashfs-factory.bin"
-      ]
-    },
-    "ZyXEL NBG-419N": {
-      "id": "zyxel_nbg-419n",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-zyxel_nbg-419n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ALFA Networks W502U": {
-      "id": "alfa-network_w502u",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-alfa-network_w502u-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Hauppauge Broadway": {
-      "id": "hauppauge_broadway",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-hauppauge_broadway-squashfs-sysupgrade.bin"
-      ]
-    },
-    "HAME MPR A2": {
-      "id": "hame_mpr-a2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-hame_mpr-a2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Tenda W306R V2.0": {
-      "id": "tenda_w306r-v2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-tenda_w306r-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Sparklan WCR-150GN": {
-      "id": "sparklan_wcr-150gn",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-sparklan_wcr-150gn-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Huawei D105": {
-      "id": "huawei_d105",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-huawei_d105-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-620 A1": {
-      "id": "dlink_dir-620-a1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-620-a1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "7Links PX-4885 8M": {
-      "id": "7links_px-4885-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-7links_px-4885-8m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "UPVEL UR-336UN": {
-      "id": "upvel_ur-336un",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-upvel_ur-336un-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Edimax 3g-6200nl": {
-      "id": "edimax_3g-6200nl",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-edimax_3g-6200nl-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AsiaRF AWAPN2403": {
-      "id": "asiarf_awapn2403",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-asiarf_awapn2403-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Accton WR6202": {
-      "id": "accton_wr6202",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-accton_wr6202-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Planex MZK-DP150N": {
-      "id": "planex_mzk-dp150n",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-planex_mzk-dp150n-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-lantiq-xway-avm_fritz7320-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
     },
     "7Links PX-4885 4M": {
       "id": "7links_px-4885-4m",
-      "target": "ramips/rt305x",
       "images": [
-        "openwrt-ramips-rt305x-7links_px-4885-4m-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ramips-rt305x-7links_px-4885-4m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
     },
-    "EasyAcc WIZARD 8800": {
-      "id": "easyacc_wizard-8800",
-      "target": "ramips/rt305x",
+    "7Links PX-4885 8M": {
+      "id": "7links_px-4885-8m",
       "images": [
-        "openwrt-ramips-rt305x-easyacc_wizard-8800-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Alpha ASL26555": {
-      "id": "alphanetworks_asl26555-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-alphanetworks_asl26555-8m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "EnGenius ESR-9753": {
-      "id": "engenius_esr-9753",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-engenius_esr-9753-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Poray M4 8M": {
-      "id": "poray_m4-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-poray_m4-8m-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-poray_m4-8m-squashfs-factory.bin"
-      ]
-    },
-    "AXIMCom MR-102N": {
-      "id": "aximcom_mr-102n",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-aximcom_mr-102n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DAP-1350": {
-      "id": "dlink_dap-1350",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dap-1350-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-dlink_dap-1350-squashfs-factory-NA.bin",
-        "openwrt-ramips-rt305x-dlink_dap-1350-squashfs-factory.bin"
-      ]
-    },
-    "D-Link DIR-300 B1": {
-      "id": "dlink_dir-300-b1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-300-b1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-dlink_dir-300-b1-squashfs-factory.bin"
-      ]
-    },
-    "Nexx WT1520 8M": {
-      "id": "nexx_wt1520-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-nexx_wt1520-8m-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-nexx_wt1520-8m-squashfs-factory.bin"
-      ]
-    },
-    "Sitecom WL-351 v1": {
-      "id": "sitecom_wl-351",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-sitecom_wl-351-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TRENDnet TEW-638APB v2": {
-      "id": "trendnet_tew-638apb-v2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-trendnet_tew-638apb-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZyXEL NBG-419N v2": {
-      "id": "zyxel_nbg-419n-v2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-zyxel_nbg-419n-v2-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ramips-rt305x-7links_px-4885-8m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
     },
     "8devices Carambola": {
       "id": "8devices_carambola",
-      "target": "ramips/rt305x",
       "images": [
-        "openwrt-ramips-rt305x-8devices_carambola-squashfs-sysupgrade.bin"
-      ]
-    },
-    "HAME MPR A1": {
-      "id": "hame_mpr-a1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-hame_mpr-a1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-615 H1": {
-      "id": "dlink_dir-615-h1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-615-h1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-dlink_dir-615-h1-squashfs-factory.bin"
-      ]
-    },
-    "Tenda 3G300M": {
-      "id": "tenda_3g300m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-tenda_3g300m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-620 D1": {
-      "id": "dlink_dir-620-d1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-620-d1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ralink WR512-3GN 8M": {
-      "id": "unbranded_wr512-3gn-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-unbranded_wr512-3gn-8m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Intenso Memory 2 Move": {
-      "id": "intenso_memory2move",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-intenso_memory2move-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Omnima MiniEMBPlug": {
-      "id": "omnima_miniembplug",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-omnima_miniembplug-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Teltonika RUT5XX": {
-      "id": "teltonika_rut5xx",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-teltonika_rut5xx-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Allnet ALL5002": {
-      "id": "allnet_all5002",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-allnet_all5002-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AirLive Air3GII": {
-      "id": "airlive_air3gii",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-airlive_air3gii-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-320 B1": {
-      "id": "dlink_dir-320-b1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-320-b1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Nexx WT1520 4M": {
-      "id": "nexx_wt1520-4m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-nexx_wt1520-4m-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-nexx_wt1520-4m-squashfs-factory.bin"
-      ]
-    },
-    "VoCore VoCore 8M": {
-      "id": "vocore_vocore-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-vocore_vocore-8m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-615 D": {
-      "id": "dlink_dir-615-d",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-615-d-squashfs-factory.bin",
-        "openwrt-ramips-rt305x-dlink_dir-615-d-squashfs-sysupgrade.bin"
-      ]
-    },
-    "JCG JHR-N805R": {
-      "id": "jcg_jhr-n805r",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-jcg_jhr-n805r-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-jcg_jhr-n805r-squashfs-factory.bin"
-      ]
-    },
-    "Allnet ALL0256N 8M": {
-      "id": "allnet_all0256n-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-allnet_all0256n-8m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Poray X8": {
-      "id": "poray_x8",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-poray_x8-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-poray_x8-squashfs-factory.bin"
-      ]
-    },
-    "Allnet ALL5003": {
-      "id": "allnet_all5003",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-allnet_all5003-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Fon Fonera 2.0N": {
-      "id": "fon_fonera-20n",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-fon_fonera-20n-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-fon_fonera-20n-squashfs-factory.bin"
-      ]
-    },
-    "ZyXEL Keenetic Start": {
-      "id": "zyxel_keenetic-start",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-zyxel_keenetic-start-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Netcore NW718": {
-      "id": "netcore_nw718",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-netcore_nw718-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Alpha ASL26555 16M": {
-      "id": "alphanetworks_asl26555-16m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-alphanetworks_asl26555-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus WL-330N": {
-      "id": "asus_wl-330n",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-asus_wl-330n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NexAira BC2": {
-      "id": "nexaira_bc2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-nexaira_bc2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ARC Wireless FreeStation": {
-      "id": "arcwireless_freestation5",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-arcwireless_freestation5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WHR-G300N": {
-      "id": "buffalo_whr-g300n",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-buffalo_whr-g300n-squashfs-tftp.bin",
-        "openwrt-ramips-rt305x-buffalo_whr-g300n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RT-N13U": {
-      "id": "asus_rt-n13u",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-asus_rt-n13u-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-600 B1/B2": {
-      "id": "dlink_dir-600-b1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-600-b1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-dlink_dir-600-b1-squashfs-factory.bin"
-      ]
-    },
-    "Planex MZK-W300NH2": {
-      "id": "planex_mzk-w300nh2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-planex_mzk-w300nh2-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-planex_mzk-w300nh2-squashfs-factory.bin"
-      ]
-    },
-    "HooToo HT-TM02": {
-      "id": "hootoo_ht-tm02",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-hootoo_ht-tm02-squashfs-sysupgrade.bin"
-      ]
-    },
-    "OLIMEX RT5350F-OLinuXino": {
-      "id": "olimex_rt5350f-olinuxino",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-olimex_rt5350f-olinuxino-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Petatel PSR-680W Wireless 3G Router": {
-      "id": "petatel_psr-680w",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-petatel_psr-680w-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR WNCE2001": {
-      "id": "netgear_wnce2001",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-netgear_wnce2001-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-netgear_wnce2001-squashfs-factory.bin",
-        "openwrt-ramips-rt305x-netgear_wnce2001-squashfs-factory-NA.bin"
-      ]
-    },
-    "Skyline SL-R7205 Wireless 3G Router": {
-      "id": "skyline_sl-r7205",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-skyline_sl-r7205-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-610 A1": {
-      "id": "dlink_dir-610-a1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-610-a1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-dlink_dir-610-a1-squashfs-factory.bin"
-      ]
-    },
-    "Nixcore X1 16M": {
-      "id": "nixcore_x1-16m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-nixcore_x1-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Poray M3": {
-      "id": "poray_m3",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-poray_m3-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-poray_m3-squashfs-factory.bin"
-      ]
-    },
-    "Poray M4 4M": {
-      "id": "poray_m4-4m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-poray_m4-4m-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-poray_m4-4m-squashfs-factory.bin"
-      ]
-    },
-    "Edimax 3g-6200n": {
-      "id": "edimax_3g-6200n",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-edimax_3g-6200n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "WIZnet WizFi630A": {
-      "id": "wiznet_wizfi630a",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-wiznet_wizfi630a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zorlik ZL5900V2": {
-      "id": "zorlik_zl5900v2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-zorlik_zl5900v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Belkin F5D8235 v2": {
-      "id": "belkin_f5d8235-v2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-belkin_f5d8235-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "VoCore VoCore 16M": {
-      "id": "vocore_vocore-16m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-vocore_vocore-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Tenda 3G150B": {
-      "id": "tenda_3g150b",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-tenda_3g150b-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ralink AP-RT3052-V22RW-2X2": {
-      "id": "ralink_v22rw-2x2",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-ralink_v22rw-2x2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Omnima MiniEMBWiFi": {
-      "id": "omnima_miniembwifi",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-omnima_miniembwifi-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Nixcore X1 8M": {
-      "id": "nixcore_x1-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-nixcore_x1-8m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-300 B7": {
-      "id": "dlink_dir-300-b7",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dir-300-b7-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RT-G32 B1": {
-      "id": "asus_rt-g32-b1",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-asus_rt-g32-b1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "HuaWei HG255D": {
-      "id": "huawei_hg255d",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-huawei_hg255d-squashfs-sysupgrade.bin"
-      ]
-    },
-    "XDX RN502J": {
-      "id": "unbranded_xdx-rn502j",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-unbranded_xdx-rn502j-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Argus ATP-52B": {
-      "id": "argus_atp-52b",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-argus_atp-52b-squashfs-sysupgrade.bin"
-      ]
-    },
-    "UPVEL UR-326N4G": {
-      "id": "upvel_ur-326n4g",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-upvel_ur-326n4g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TRENDnet TEW-714TRU": {
-      "id": "trendnet_tew-714tru",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-trendnet_tew-714tru-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AsiaRF AWM002-EVB 4M": {
-      "id": "asiarf_awm002-evb-4m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-asiarf_awm002-evb-4m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Planex MZK-WDPR": {
-      "id": "planex_mzk-wdpr",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-planex_mzk-wdpr-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Belkin F7C027": {
-      "id": "belkin_f7c027",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-belkin_f7c027-squashfs-sysupgrade.bin"
-      ]
-    },
-    "A5-V11": {
-      "id": "unbranded_a5-v11",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-unbranded_a5-v11-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-unbranded_a5-v11-squashfs-factory.bin"
-      ]
-    },
-    "AsiaRF AWM002-EVB/AWM003-EVB 8M": {
-      "id": "asiarf_awm002-evb-8m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-asiarf_awm002-evb-8m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RT-N10+": {
-      "id": "asus_rt-n10-plus",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-asus_rt-n10-plus-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Wansview NCS601W": {
-      "id": "wansview_ncs601w",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-wansview_ncs601w-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Allnet ALL0256N 4M": {
-      "id": "allnet_all0256n-4m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-allnet_all0256n-4m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZyXEL Keenetic": {
-      "id": "zyxel_keenetic",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-zyxel_keenetic-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus WL-330N3G": {
-      "id": "asus_wl-330n3g",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-asus_wl-330n3g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Prolink PWH2004": {
-      "id": "prolink_pwh2004",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-prolink_pwh2004-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Tenda W150M": {
-      "id": "tenda_w150m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-tenda_w150m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DWR-512 B": {
-      "id": "dlink_dwr-512-b",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-dlink_dwr-512-b-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt305x-dlink_dwr-512-b-squashfs-factory.bin"
-      ]
-    },
-    "JCG JHR-N825R": {
-      "id": "jcg_jhr-n825r",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-jcg_jhr-n825r-squashfs-factory.bin",
-        "openwrt-ramips-rt305x-jcg_jhr-n825r-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ralink WR512-3GN 4M": {
-      "id": "unbranded_wr512-3gn-4m",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-unbranded_wr512-3gn-4m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Poray X5/X6": {
-      "id": "poray_x5",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-poray_x5-squashfs-factory.bin",
-        "openwrt-ramips-rt305x-poray_x5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "OLIMEX RT5350F-OLinuXino-EVB": {
-      "id": "olimex_rt5350f-olinuxino-evb",
-      "target": "ramips/rt305x",
-      "images": [
-        "openwrt-ramips-rt305x-olimex_rt5350f-olinuxino-evb-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Loewe WMDR-143N": {
-      "id": "loewe_wmdr-143n",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-loewe_wmdr-143n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Omnima HPM": {
-      "id": "omnima_hpm",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-omnima_hpm-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Edimax BR-6475nD": {
-      "id": "edimax_br-6475nd",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-edimax_br-6475nd-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Samsung CY-SWR1100": {
-      "id": "samsung_cy-swr1100",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-samsung_cy-swr1100-squashfs-factory.bin",
-        "openwrt-ramips-rt3883-samsung_cy-swr1100-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RT-N56U": {
-      "id": "asus_rt-n56u",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-asus_rt-n56u-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Belkin F9K1109 Version 1.0": {
-      "id": "belkin_f9k1109v1",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-belkin_f9k1109v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-645": {
-      "id": "dlink_dir-645",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-dlink_dir-645-squashfs-factory.bin",
-        "openwrt-ramips-rt3883-dlink_dir-645-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TRENDnet TEW-692GR": {
-      "id": "trendnet_tew-692gr",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-trendnet_tew-692gr-squashfs-factory.bin",
-        "openwrt-ramips-rt3883-trendnet_tew-692gr-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Sitecom WLR-6000": {
-      "id": "sitecom_wlr-6000",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-sitecom_wlr-6000-squashfs-factory.dlf",
-        "openwrt-ramips-rt3883-sitecom_wlr-6000-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TRENDnet TEW-691GR": {
-      "id": "trendnet_tew-691gr",
-      "target": "ramips/rt3883",
-      "images": [
-        "openwrt-ramips-rt3883-trendnet_tew-691gr-squashfs-factory.bin",
-        "openwrt-ramips-rt3883-trendnet_tew-691gr-squashfs-sysupgrade.bin"
-      ]
-    },
-    "WRTnode WRTnode 2R": {
-      "id": "wrtnode_wrtnode2r",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-wrtnode_wrtnode2r-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Xiaomi Mi Router 4A 100M Edition": {
-      "id": "xiaomi_mir4a-100m",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-xiaomi_mir4a-100m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "DuZun DM06": {
-      "id": "duzun_dm06",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-duzun_dm06-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C20 v5": {
-      "id": "tplink_archer-c20-v5",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_archer-c20-v5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WA801ND v5": {
-      "id": "tplink_tl-wa801nd-v5",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-wa801nd-v5-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-wa801nd-v5-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "Onion Omega2+": {
-      "id": "onion_omega2p",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-onion_omega2p-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link RE305 v1": {
-      "id": "tplink_re305-v1",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_re305-v1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_re305-v1-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C20 v4": {
-      "id": "tplink_archer-c20-v4",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_archer-c20-v4-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_archer-c20-v4-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "VoCore VoCore2-Lite": {
-      "id": "vocore_vocore2-lite",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-vocore_vocore2-lite-squashfs-sysupgrade.bin"
-      ]
-    },
-    "HiWiFi HC5861B": {
-      "id": "hiwifi_hc5861b",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-hiwifi_hc5861b-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ALFA Network AWUSFREE1": {
-      "id": "alfa-network_awusfree1",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-alfa-network_awusfree1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "HILINK HLK-7628N": {
-      "id": "hilink_hlk-7628n",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-hilink_hlk-7628n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek LinkIt Smart 7688": {
-      "id": "mediatek_linkit-smart-7688",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-mediatek_linkit-smart-7688-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ipTIME A3": {
-      "id": "iptime_a3",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-iptime_a3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ipTIME A604M": {
-      "id": "iptime_a604m",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-iptime_a604m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek MT7628 EVB": {
-      "id": "mediatek_mt7628an-eval-board",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-mediatek_mt7628an-eval-board-squashfs-sysupgrade.bin"
-      ]
-    },
-    "VoCore VoCore2": {
-      "id": "vocore_vocore2",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-vocore_vocore2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WE1226": {
-      "id": "zbtlink_zbt-we1226",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-zbtlink_zbt-we1226-squashfs-sysupgrade.bin"
-      ]
-    },
-    "WIZnet WizFi630S": {
-      "id": "wiznet_wizfi630s",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-wiznet_wizfi630s-squashfs-sysupgrade.bin"
-      ]
-    },
-    "PandoraBox PBR-D1": {
-      "id": "d-team_pbr-d1",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-d-team_pbr-d1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR902AC v3": {
-      "id": "tplink_tl-wr902ac-v3",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-wr902ac-v3-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-wr902ac-v3-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "Xiaomi MiWiFi Nano": {
-      "id": "xiaomi_miwifi-nano",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-xiaomi_miwifi-nano-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Onion Omega2": {
-      "id": "onion_omega2",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-onion_omega2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WCR-1166DS": {
-      "id": "buffalo_wcr-1166ds",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-buffalo_wcr-1166ds-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-buffalo_wcr-1166ds-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-MR3020 v3": {
-      "id": "tplink_tl-mr3020-v3",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-mr3020-v3-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-mr3020-v3-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "TP-Link Archer C50 v4": {
-      "id": "tplink_archer-c50-v4",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_archer-c50-v4-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZyXEL Keenetic Extra II": {
-      "id": "zyxel_keenetic-extra-ii",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-zyxel_keenetic-extra-ii-squashfs-factory.bin",
-        "openwrt-ramips-mt76x8-zyxel_keenetic-extra-ii-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR R6120": {
-      "id": "netgear_r6120",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-netgear_r6120-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-netgear_r6120-squashfs-factory.img"
-      ]
-    },
-    "TP-Link TL-WR841N v13": {
-      "id": "tplink_tl-wr841n-v13",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-wr841n-v13-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-wr841n-v13-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "TP-Link TL-WR840N v5": {
-      "id": "tplink_tl-wr840n-v5",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-wr840n-v5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR842N v5": {
-      "id": "tplink_tl-wr842n-v5",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-wr842n-v5-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-wr842n-v5-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "Rakwireless RAK633": {
-      "id": "rakwireless_rak633",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-rakwireless_rak633-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR802N v4": {
-      "id": "tplink_tl-wr802n-v4",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-wr802n-v4-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-wr802n-v4-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "GL.iNet VIXMINI": {
-      "id": "glinet_vixmini",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-glinet_vixmini-squashfs-sysupgrade.bin"
-      ]
-    },
-    "WRTnode WRTnode 2P": {
-      "id": "wrtnode_wrtnode2p",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-wrtnode_wrtnode2p-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-MT300N V2": {
-      "id": "glinet_gl-mt300n-v2",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-glinet_gl-mt300n-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Skylab SKW92A": {
-      "id": "skylab_skw92a",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-skylab_skw92a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Wavlink WL-WN575A3": {
-      "id": "wavlink_wl-wn575a3",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-wavlink_wl-wn575a3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-MR3420 v5": {
-      "id": "tplink_tl-mr3420-v5",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-mr3420-v5-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-mr3420-v5-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "Cudy WR1000": {
-      "id": "cudy_wr1000",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-cudy_wr1000-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-cudy_wr1000-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link TL-WR841N v14": {
-      "id": "tplink_tl-wr841n-v14",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-wr841n-v14-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-wr841n-v14-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "HiWiFi HC5761A": {
-      "id": "hiwifi_hc5761a",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-hiwifi_hc5761a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Mercury MAC1200R v2.0": {
-      "id": "mercury_mac1200r-v2",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-mercury_mac1200r-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C50 v3": {
-      "id": "tplink_archer-c50-v3",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_archer-c50-v3-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_archer-c50-v3-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "Wavlink WL-WN570HA1": {
-      "id": "wavlink_wl-wn570ha1",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-wavlink_wl-wn570ha1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Tama W06": {
-      "id": "tama_w06",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tama_w06-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TOTOLINK LR1200": {
-      "id": "totolink_lr1200",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-totolink_lr1200-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Widora Widora-NEO 32M": {
-      "id": "widora_neo-32m",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-widora_neo-32m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Widora Widora-NEO 16M": {
-      "id": "widora_neo-16m",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-widora_neo-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link TL-WR840N v4": {
-      "id": "tplink_tl-wr840n-v4",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-tplink_tl-wr840n-v4-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt76x8-tplink_tl-wr840n-v4-squashfs-tftp-recovery.bin"
-      ]
-    },
-    "HiWiFi HC5661A": {
-      "id": "hiwifi_hc5661a",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-hiwifi_hc5661a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "UniElec U7628-01 16M": {
-      "id": "unielec_u7628-01-16m",
-      "target": "ramips/mt76x8",
-      "images": [
-        "openwrt-ramips-mt76x8-unielec_u7628-01-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Dovado Tiny AC": {
-      "id": "dovado_tiny-ac",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dovado_tiny-ac-squashfs-sysupgrade.bin"
-      ]
-    },
-    "WRTNode WRTNode": {
-      "id": "wrtnode_wrtnode",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-wrtnode_wrtnode-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Comfast CF-WR800N": {
-      "id": "comfast_cf-wr800n",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-comfast_cf-wr800n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Linksys E1700": {
-      "id": "linksys_e1700",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-linksys_e1700-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-linksys_e1700-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C20 v1": {
-      "id": "tplink_archer-c20-v1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-tplink_archer-c20-v1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-tplink_archer-c20-v1-squashfs-factory.bin"
-      ]
-    },
-    "ALFA Network AC1200RM": {
-      "id": "alfa-network_ac1200rm",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-alfa-network_ac1200rm-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WHR-300HP2": {
-      "id": "buffalo_whr-300hp2",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-buffalo_whr-300hp2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Kingston MLW221": {
-      "id": "kingston_mlw221",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-kingston_mlw221-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-APE522II": {
-      "id": "zbtlink_zbt-ape522ii",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-ape522ii-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Nexx WT3020 4M": {
-      "id": "nexx_wt3020-4m",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-nexx_wt3020-4m-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-nexx_wt3020-4m-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C20i": {
-      "id": "tplink_archer-c20i",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-tplink_archer-c20i-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-tplink_archer-c20i-squashfs-factory.bin"
-      ]
-    },
-    "Edimax EW-7476RPC": {
-      "id": "edimax_ew-7476rpc",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-edimax_ew-7476rpc-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-MT750": {
-      "id": "glinet_gl-mt750",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-glinet_gl-mt750-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WE826 16M": {
-      "id": "zbtlink_zbt-we826-16m",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-we826-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RT-AC51U": {
-      "id": "asus_rt-ac51u",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-asus_rt-ac51u-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Microduino MicroWRT": {
-      "id": "microduino_microwrt",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-microduino_microwrt-squashfs-sysupgrade.bin"
-      ]
-    },
-    "EnGenius ESR600": {
-      "id": "engenius_esr600",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-engenius_esr600-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-engenius_esr600-squashfs-factory.dlf"
-      ]
-    },
-    "ZyXEL Keenetic Viva": {
-      "id": "zyxel_keenetic-viva",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zyxel_keenetic-viva-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-zyxel_keenetic-viva-squashfs-factory.bin"
-      ]
-    },
-    "ZTE Q7": {
-      "id": "zte_q7",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zte_q7-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Kingston MLWG2": {
-      "id": "kingston_mlwg2",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-kingston_mlwg2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Elecom WRH-300CR": {
-      "id": "elecom_wrh-300cr",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-elecom_wrh-300cr-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-elecom_wrh-300cr-squashfs-factory.bin"
-      ]
-    },
-    "Sercomm NA930": {
-      "id": "sercomm_na930",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-sercomm_na930-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RT-N14u": {
-      "id": "asus_rt-n14u",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-asus_rt-n14u-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Planex MZK-750DHP": {
-      "id": "planex_mzk-750dhp",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-planex_mzk-750dhp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-MT300A": {
-      "id": "glinet_gl-mt300a",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-glinet_gl-mt300a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Edimax EW-7478AC": {
-      "id": "edimax_ew-7478ac",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-edimax_ew-7478ac-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DWR-116 A1/A2": {
-      "id": "dlink_dwr-116-a1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dwr-116-a1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-dlink_dwr-116-a1-squashfs-factory.bin"
-      ]
-    },
-    "D-Link DWR-922 E2": {
-      "id": "dlink_dwr-922-e2",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dwr-922-e2-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-dlink_dwr-922-e2-squashfs-factory.bin"
-      ]
-    },
-    "Phicomm PSG1218 Bx": {
-      "id": "phicomm_psg1218b",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-phicomm_psg1218b-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Kimax U35WF": {
-      "id": "kimax_u35wf",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-kimax_u35wf-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Head Weblink HDRM2000": {
-      "id": "head-weblink_hdrm200",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-head-weblink_hdrm200-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WE1026-5G 16M": {
-      "id": "zbtlink_zbt-we1026-5g-16m",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-we1026-5g-16m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DCH-M225": {
-      "id": "dlink_dch-m225",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dch-m225-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-dlink_dch-m225-squashfs-factory.bin"
-      ]
-    },
-    "HNET C108": {
-      "id": "hnet_c108",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-hnet_c108-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek MT7620a EVB": {
-      "id": "ralink_mt7620a-evb",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-ralink_mt7620a-evb-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WR8305RT": {
-      "id": "zbtlink_zbt-wr8305rt",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-wr8305rt-squashfs-sysupgrade.bin"
-      ]
-    },
-    "LAVA LR-25G001": {
-      "id": "lava_lr-25g001",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-lava_lr-25g001-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-lava_lr-25g001-squashfs-factory.bin"
-      ]
-    },
-    "Xiaomi MiWiFi Mini": {
-      "id": "xiaomi_miwifi-mini",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-xiaomi_miwifi-mini-squashfs-sysupgrade.bin"
-      ]
-    },
-    "YOUKU YK1": {
-      "id": "youku_yk1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-youku_yk1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR EX6130": {
-      "id": "netgear_ex6130",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-netgear_ex6130-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-netgear_ex6130-squashfs-factory.chk"
-      ]
-    },
-    "Zbtlink ZBT-WE826 32M": {
-      "id": "zbtlink_zbt-we826-32m",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-we826-32m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WMR-300": {
-      "id": "buffalo_wmr-300",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-buffalo_wmr-300-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Phicomm K2G": {
-      "id": "phicomm_k2g",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-phicomm_k2g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Aigale Ai-BR100": {
-      "id": "aigale_ai-br100",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-aigale_ai-br100-squashfs-sysupgrade.bin"
-      ]
-    },
-    "HiWiFi HC5661": {
-      "id": "hiwifi_hc5661",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-hiwifi_hc5661-squashfs-sysupgrade.bin"
-      ]
-    },
-    "I-O DATA WN-AC1167GR": {
-      "id": "iodata_wn-ac1167gr",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-iodata_wn-ac1167gr-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-iodata_wn-ac1167gr-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link RE200 v1": {
-      "id": "tplink_re200-v1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-tplink_re200-v1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-tplink_re200-v1-squashfs-factory.bin"
-      ]
-    },
-    "Edimax BR-6478AC V2": {
-      "id": "edimax_br-6478ac-v2",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-edimax_br-6478ac-v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WA05": {
-      "id": "zbtlink_zbt-wa05",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-wa05-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-810L": {
-      "id": "dlink_dir-810l",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dir-810l-squashfs-sysupgrade.bin"
-      ]
-    },
-    "BDCOM WAP2100-SK (ZTE ZXECS EBG3130)": {
-      "id": "bdcom_wap2100-sk",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-bdcom_wap2100-sk-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lenovo Y1": {
-      "id": "lenovo_newifi-y1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-lenovo_newifi-y1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Planex MZK-EX300NP": {
-      "id": "planex_mzk-ex300np",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-planex_mzk-ex300np-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek MT7620a + MT7530 EVB": {
-      "id": "ralink_mt7620a-mt7530-evb",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-ralink_mt7620a-mt7530-evb-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WE2026": {
-      "id": "zbtlink_zbt-we2026",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-we2026-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Sanlinking Technologies D240": {
-      "id": "sanlinking_d240",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-sanlinking_d240-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Planex CS-QR10": {
-      "id": "planex_cs-qr10",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-planex_cs-qr10-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Vonets VAR11N-300": {
-      "id": "vonets_var11n-300",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-vonets_var11n-300-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR EX2700": {
-      "id": "netgear_ex2700",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-netgear_ex2700-squashfs-factory.bin",
-        "openwrt-ramips-mt7620-netgear_ex2700-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-MT300N": {
-      "id": "glinet_gl-mt300n",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-glinet_gl-mt300n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Nexx WT3020 8M": {
-      "id": "nexx_wt3020-8m",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-nexx_wt3020-8m-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-nexx_wt3020-8m-squashfs-factory.bin"
-      ]
-    },
-    "HiWiFi HC5761": {
-      "id": "hiwifi_hc5761",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-hiwifi_hc5761-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Phicomm PSG1218 Ax": {
-      "id": "phicomm_psg1218a",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-phicomm_psg1218a-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ALFA Network R36M-E4G": {
-      "id": "alfa-network_r36m-e4g",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-alfa-network_r36m-e4g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DWR-118 A1": {
-      "id": "dlink_dwr-118-a1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dwr-118-a1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-dlink_dwr-118-a1-squashfs-factory.bin"
-      ]
-    },
-    "Buffalo WHR-1166D": {
-      "id": "buffalo_whr-1166d",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-buffalo_whr-1166d-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Lenovo Y1S": {
-      "id": "lenovo_newifi-y1s",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-lenovo_newifi-y1s-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-CPE102": {
-      "id": "zbtlink_zbt-cpe102",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-cpe102-squashfs-sysupgrade.bin"
-      ]
-    },
-    "HiWiFi HC5861": {
-      "id": "hiwifi_hc5861",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-hiwifi_hc5861-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Planex DB-WRT01": {
-      "id": "planex_db-wrt01",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-planex_db-wrt01-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DWR-921 C3": {
-      "id": "dlink_dwr-921-c3",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dwr-921-c3-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-dlink_dwr-921-c3-squashfs-factory.bin"
-      ]
-    },
-    "Planex MZK-EX750NP": {
-      "id": "planex_mzk-ex750np",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-planex_mzk-ex750np-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DWR-921 C1": {
-      "id": "dlink_dwr-921-c1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dwr-921-c1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-dlink_dwr-921-c1-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer MR200": {
-      "id": "tplink_archer-mr200",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-tplink_archer-mr200-squashfs-sysupgrade.bin"
-      ]
-    },
-    "YUKAI Engineering BOCCO": {
-      "id": "yukai_bocco",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-yukai_bocco-squashfs-sysupgrade.bin"
-      ]
-    },
-    "I-O DATA WN-AC733GR3": {
-      "id": "iodata_wn-ac733gr3",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-iodata_wn-ac733gr3-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-iodata_wn-ac733gr3-squashfs-factory.bin"
-      ]
-    },
-    "D-Link DWR-118 A2": {
-      "id": "dlink_dwr-118-a2",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dwr-118-a2-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-dlink_dwr-118-a2-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR WN3000RP v3": {
-      "id": "netgear_wn3000rp-v3",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-netgear_wn3000rp-v3-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-netgear_wn3000rp-v3-squashfs-factory.bin"
-      ]
-    },
-    "TP-Link Archer C50 v1": {
-      "id": "tplink_archer-c50-v1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-tplink_archer-c50-v1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-tplink_archer-c50-v1-squashfs-factory-eu.bin",
-        "openwrt-ramips-mt7620-tplink_archer-c50-v1-squashfs-factory-us.bin"
-      ]
-    },
-    "Fon FON2601": {
-      "id": "fon_fon2601",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-fon_fon2601-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ZyXEL Keenetic Omni II": {
-      "id": "zyxel_keenetic-omni-ii",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zyxel_keenetic-omni-ii-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-zyxel_keenetic-omni-ii-squashfs-factory.bin"
-      ]
-    },
-    "ZyXEL Keenetic Omni": {
-      "id": "zyxel_keenetic-omni",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zyxel_keenetic-omni-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-zyxel_keenetic-omni-squashfs-factory.bin"
-      ]
-    },
-    "Phicomm PSG1208": {
-      "id": "phicomm_psg1208",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-phicomm_psg1208-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ipTIME A104ns": {
-      "id": "iptime_a104ns",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-iptime_a104ns-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Edimax EW-7478APC": {
-      "id": "edimax_ew-7478apc",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-edimax_ew-7478apc-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RP-N53": {
-      "id": "asus_rp-n53",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-asus_rp-n53-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ALFA Network Tube-E4G": {
-      "id": "alfa-network_tube-e4g",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-alfa-network_tube-e4g-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Oh Yeah OY-0001": {
-      "id": "ohyeah_oy-0001",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-ohyeah_oy-0001-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ravpower WD03": {
-      "id": "ravpower_wd03",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-ravpower_wd03-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WE826-E": {
-      "id": "zbtlink_zbt-we826-e",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-we826-e-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR EX3700/EX3800": {
-      "id": "netgear_ex3700",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-netgear_ex3700-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-netgear_ex3700-squashfs-factory.chk"
-      ]
-    },
-    "TP-Link Archer C2 v1": {
-      "id": "tplink_archer-c2-v1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-tplink_archer-c2-v1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-tplink_archer-c2-v1-squashfs-factory.bin"
-      ]
-    },
-    "Kimax U25AWF H1": {
-      "id": "kimax_u25awf-h1",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-kimax_u25awf-h1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Zbtlink ZBT-WE1026-H 32M": {
-      "id": "zbtlink_zbt-we1026-h-32m",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-zbtlink_zbt-we1026-h-32m-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MediaTek MT7620a + MT7610e EVB": {
-      "id": "ralink_mt7620a-mt7610e-evb",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-ralink_mt7620a-mt7610e-evb-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WHR-600D": {
-      "id": "buffalo_whr-600d",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-buffalo_whr-600d-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DIR-510L": {
-      "id": "dlink_dir-510l",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-dlink_dir-510l-squashfs-sysupgrade.bin",
-        "openwrt-ramips-mt7620-dlink_dir-510l-squashfs-factory.bin"
-      ]
-    },
-    "MediaTek MT7620a V22SG": {
-      "id": "ralink_mt7620a-v22sg-evb",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-ralink_mt7620a-v22sg-evb-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RT-N11P/RT-N12+/RT-N12Eb1": {
-      "id": "asus_rt-n12p",
-      "target": "ramips/mt7620",
-      "images": [
-        "openwrt-ramips-mt7620-asus_rt-n12p-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DAP-1522 A1": {
-      "id": "dlink_dap-1522-a1",
-      "target": "ramips/rt288x",
-      "images": [
-        "openwrt-ramips-rt288x-dlink_dap-1522-a1-squashfs-sysupgrade.bin",
-        "openwrt-ramips-rt288x-dlink_dap-1522-a1-squashfs-factory.bin"
-      ]
-    },
-    "Buffalo WLI-TX4-AG300N": {
-      "id": "buffalo_wli-tx4-ag300n",
-      "target": "ramips/rt288x",
-      "images": [
-        "openwrt-ramips-rt288x-buffalo_wli-tx4-ag300n-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Belkin F5D8235 V1": {
-      "id": "belkin_f5d8235-v1",
-      "target": "ramips/rt288x",
-      "images": [
-        "openwrt-ramips-rt288x-belkin_f5d8235-v1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WZR-AGL300NH": {
-      "id": "buffalo_wzr-agl300nh",
-      "target": "ramips/rt288x",
-      "images": [
-        "openwrt-ramips-rt288x-buffalo_wzr-agl300nh-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ralink V11ST-FE": {
-      "id": "ralink_v11st-fe",
-      "target": "ramips/rt288x",
-      "images": [
-        "openwrt-ramips-rt288x-ralink_v11st-fe-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Airlink AR725W": {
-      "id": "airlink101_ar725w",
-      "target": "ramips/rt288x",
-      "images": [
-        "openwrt-ramips-rt288x-airlink101_ar725w-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Asus RT-N15": {
-      "id": "asus_rt-n15",
-      "target": "ramips/rt288x",
-      "images": [
-        "openwrt-ramips-rt288x-asus_rt-n15-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Airlink AR670W": {
-      "id": "airlink101_ar670w",
-      "target": "ramips/rt288x",
-      "images": [
-        "openwrt-ramips-rt288x-airlink101_ar670w-squashfs-factory.bin",
-        "openwrt-ramips-rt288x-airlink101_ar670w-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Atheros Generic AR2xxx board": {
-      "id": "generic",
-      "target": "ath25",
-      "images": [
-        "openwrt-ath25-generic-kernel.elf",
-        "openwrt-ath25-generic-squashfs-rootfs.bin",
-        "openwrt-ath25-generic-squashfs-sysupgrade.bin",
-        "openwrt-ath25-generic-kernel.gz",
-        "openwrt-ath25-generic-kernel.lzma"
-      ]
-    },
-    "Ubiquiti XS2": {
-      "id": "ubnt2",
-      "target": "ath25",
-      "images": [
-        "openwrt-ath25-ubnt2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti XS2-8": {
-      "id": "ubnt2-pico2",
-      "target": "ath25",
-      "images": [
-        "openwrt-ath25-ubnt2-pico2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Ubiquiti XS5": {
-      "id": "ubnt5",
-      "target": "ath25",
-      "images": [
-        "openwrt-ath25-ubnt5-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Qualcomm AP148 standard": {
-      "id": "qcom_ipq8064-ap148",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-qcom_ipq8064-ap148-squashfs-nand-factory.bin",
-        "openwrt-ipq806x-generic-qcom_ipq8064-ap148-squashfs-nand-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WXR-2533DHP": {
-      "id": "buffalo_wxr-2533dhp",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-buffalo_wxr-2533dhp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Qualcomm AP148 legacy": {
-      "id": "qcom_ipq8064-ap148-legacy",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-qcom_ipq8064-ap148-legacy-squashfs-nand-factory.bin",
-        "openwrt-ipq806x-generic-qcom_ipq8064-ap148-legacy-squashfs-nand-sysupgrade.bin"
-      ]
-    },
-    "Qualcomm AP161": {
-      "id": "qcom_ipq8064-ap161",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-qcom_ipq8064-ap161-squashfs-nand-factory.bin",
-        "openwrt-ipq806x-generic-qcom_ipq8064-ap161-squashfs-nand-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR Nighthawk X4 D7800": {
-      "id": "netgear_d7800",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-netgear_d7800-squashfs-sysupgrade.bin",
-        "openwrt-ipq806x-generic-netgear_d7800-squashfs-factory.img"
-      ]
-    },
-    "ZyXEL NBG6817": {
-      "id": "zyxel_nbg6817",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-zyxel_nbg6817-squashfs-sysupgrade.bin",
-        "openwrt-ipq806x-generic-zyxel_nbg6817-squashfs-factory.bin"
-      ]
-    },
-    "NETGEAR Nighthawk X4 R7500 v2": {
-      "id": "netgear_r7500v2",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-netgear_r7500v2-squashfs-factory.img",
-        "openwrt-ipq806x-generic-netgear_r7500v2-squashfs-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer C2600 v1": {
-      "id": "tplink_c2600",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-tplink_c2600-squashfs-factory.bin",
-        "openwrt-ipq806x-generic-tplink_c2600-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Linksys EA8500": {
-      "id": "linksys_ea8500",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-linksys_ea8500-squashfs-factory.bin",
-        "openwrt-ipq806x-generic-linksys_ea8500-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR Nighthawk X4 R7500 v1": {
-      "id": "netgear_r7500",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-netgear_r7500-squashfs-factory.img",
-        "openwrt-ipq806x-generic-netgear_r7500-squashfs-sysupgrade.bin"
-      ]
-    },
-    "NETGEAR Nighthawk X4S R7800": {
-      "id": "netgear_r7800",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-netgear_r7800-squashfs-sysupgrade.bin",
-        "openwrt-ipq806x-generic-netgear_r7800-squashfs-factory.img"
-      ]
-    },
-    "NEC Aterm WG2600HP": {
-      "id": "nec_wg2600hp",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-nec_wg2600hp-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Compex WPQ864": {
-      "id": "compex_wpq864",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-compex_wpq864-squashfs-nand-factory.bin",
-        "openwrt-ipq806x-generic-compex_wpq864-squashfs-nand-sysupgrade.bin"
-      ]
-    },
-    "TP-Link Archer VR2600v v1": {
-      "id": "tplink_vr2600v",
-      "target": "ipq806x/generic",
-      "images": [
-        "openwrt-ipq806x-generic-tplink_vr2600v-squashfs-sysupgrade.bin"
-      ]
-    },
-    "MikroTik RouterBOARD 532": {
-      "id": "nand",
-      "target": "rb532",
-      "images": [
-        "openwrt-rb532-nand-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Buffalo WZR-600DHP2": {
-      "id": "buffalo-wzr-600dhp2",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-buffalo-wzr-600dhp2-squashfs.trx"
-      ]
-    },
-    "Tenda AC9": {
-      "id": "tenda-ac9",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-tenda-ac9-squashfs.trx"
-      ]
-    },
-    "NETGEAR R6250": {
-      "id": "netgear-r6250",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-netgear-r6250-squashfs.chk"
-      ]
-    },
-    "Buffalo WZR-1750DHP": {
-      "id": "buffalo-wzr-1750dhp",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-buffalo-wzr-1750dhp-squashfs.trx"
-      ]
-    },
-    "TP-LINK Archer C5 v2": {
-      "id": "tplink-archer-c5-v2",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-tplink-archer-c5-v2-squashfs.bin"
-      ]
-    },
-    "SmartRG SR400ac": {
-      "id": "smartrg-sr400ac",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-smartrg-sr400ac-squashfs.trx"
-      ]
-    },
-    "NETGEAR R7900": {
-      "id": "netgear-r7900",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-netgear-r7900-squashfs.chk"
-      ]
-    },
-    "NETGEAR R8000": {
-      "id": "netgear-r8000",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-netgear-r8000-squashfs.chk"
-      ]
-    },
-    "ASUS RT-N18U": {
-      "id": "asus-rt-n18u",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-asus-rt-n18u-squashfs.trx"
-      ]
-    },
-    "PHICOMM K3": {
-      "id": "phicomm-k3",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-phicomm-k3-squashfs.trx"
-      ]
-    },
-    "NETGEAR R6300 v2": {
-      "id": "netgear-r6300-v2",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-netgear-r6300-v2-squashfs.chk"
-      ]
-    },
-    "Buffalo WXR-1900DHP": {
-      "id": "buffalo-wxr-1900dhp",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-buffalo-wxr-1900dhp-squashfs.trx"
-      ]
-    },
-    "TP-LINK Archer C9 v1": {
-      "id": "tplink-archer-c9-v1",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-tplink-archer-c9-v1-squashfs.bin"
-      ]
-    },
-    "Linksys EA6500 v2": {
-      "id": "linksys-ea6500-v2",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-linksys-ea6500-v2-squashfs.trx"
-      ]
-    },
-    "ASUS RT-AC68U": {
-      "id": "asus-rt-ac68u",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-asus-rt-ac68u-squashfs.trx"
-      ]
-    },
-    "ASUS RT-AC56U": {
-      "id": "asus-rt-ac56u",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-asus-rt-ac56u-squashfs.trx"
-      ]
-    },
-    "ASUS RT-AC87U": {
-      "id": "asus-rt-ac87u",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-asus-rt-ac87u-squashfs.trx"
-      ]
-    },
-    "D-Link DIR-885L": {
-      "id": "dlink-dir-885l",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-dlink-dir-885l-squashfs.bin"
-      ]
-    },
-    "Buffalo WZR-900DHP": {
-      "id": "buffalo-wzr-900dhp",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-buffalo-wzr-900dhp-squashfs.trx",
-        "openwrt-bcm53xx-generic-buffalo-wzr-900dhp-squashfs.factory-DHP-EU.bin",
-        "openwrt-bcm53xx-generic-buffalo-wzr-900dhp-squashfs.factory-DHP2-JP.bin"
-      ]
-    },
-    "NETGEAR R7000": {
-      "id": "netgear-r7000",
-      "target": "bcm53xx/generic",
-      "images": [
-        "openwrt-bcm53xx-generic-netgear-r7000-squashfs.chk"
-      ]
-    },
-    "ITian Square One SQ201": {
-      "id": "itian_sq201",
-      "target": "gemini",
-      "images": [
-        "openwrt-gemini-itian_sq201-squashfs-factory.bin"
-      ]
-    },
-    "Raidsonic NAS IB-4220-B": {
-      "id": "raidsonic_ib-4220-b",
-      "target": "gemini",
-      "images": [
-        "openwrt-gemini-raidsonic_ib-4220-b-squashfs-factory.bin"
-      ]
-    },
-    "D-Link DIR-685 Xtreme N Storage Router": {
-      "id": "dlink_dir-685",
-      "target": "gemini",
-      "images": [
-        "openwrt-gemini-dlink_dir-685-squashfs-factory.bin",
-        "openwrt-gemini-dlink_dir-685-squashfs-sysupgrade.bin"
-      ]
-    },
-    "D-Link DNS-313 1-Bay Network Storage Enclosure": {
-      "id": "dlink_dns-313",
-      "target": "gemini",
-      "images": [
-        "openwrt-gemini-dlink_dns-313-ext4-factory.bin.gz"
-      ]
-    },
-    "StorLink SL93512r": {
-      "id": "storlink_sl93512r",
-      "target": "gemini",
-      "images": [
-        "openwrt-gemini-storlink_sl93512r-squashfs-factory.bin"
-      ]
-    },
-    "CompuLab TrimSlice": {
-      "id": "compulab_trimslice",
-      "target": "tegra",
-      "images": [
-        "openwrt-tegra-compulab_trimslice-ext4-sdcard.img.gz",
-        "openwrt-tegra-compulab_trimslice-squashfs-sdcard.img.gz"
-      ]
-    },
-    "Linksys EA6350 v3": {
-      "id": "linksys_ea6350v3",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-linksys_ea6350v3-squashfs-factory.bin",
-        "openwrt-ipq40xx-generic-linksys_ea6350v3-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Linksys EA8300": {
-      "id": "linksys_ea8300",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-linksys_ea8300-squashfs-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-linksys_ea8300-squashfs-factory.bin"
-      ]
-    },
-    "AVM FRITZ!Repeater 3000": {
-      "id": "avm_fritzrepeater-3000",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-avm_fritzrepeater-3000-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Netgear EX6150 v2": {
-      "id": "netgear_ex6150v2",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-netgear_ex6150v2-squashfs-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-netgear_ex6150v2-squashfs-factory.img"
-      ]
-    },
-    "Qualcomm Atheros AP-DK01.1 C1": {
-      "id": "qcom_ap-dk01.1-c1",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-qcom_ap-dk01.1-c1-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Cisco Meraki MR33": {
-      "id": "meraki_mr33",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-meraki_mr33-squashfs-sysupgrade.bin"
-      ]
-    },
-    "GL.iNet GL-B1300": {
-      "id": "glinet_gl-b1300",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-glinet_gl-b1300-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Compex WPJ419": {
-      "id": "compex_wpj419",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-compex_wpj419-squashfs-nand-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-compex_wpj419-squashfs-nand-factory.ubi"
-      ]
-    },
-    "Crisis Innovation Lab MeshPoint.One": {
-      "id": "cilab_meshpoint-one",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-cilab_meshpoint-one-squashfs-nand-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-cilab_meshpoint-one-squashfs-nand-factory.ubi"
-      ]
-    },
-    "ASUS Lyra (MAP-AC2200)": {
-      "id": "asus_map-ac2200",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-asus_map-ac2200-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Qualcomm Atheros AP-DK04.1 C1": {
-      "id": "qcom_ap-dk04.1-c1",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-qcom_ap-dk04.1-c1-squashfs-nand-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-qcom_ap-dk04.1-c1-squashfs-nand-factory.ubi"
-      ]
-    },
-    "EnGenius ENS620EXT": {
-      "id": "engenius_ens620ext",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-engenius_ens620ext-squashfs-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-engenius_ens620ext-squashfs-factory_30.bin",
-        "openwrt-ipq40xx-generic-engenius_ens620ext-squashfs-factory_35.bin"
-      ]
-    },
-    "OpenMesh A42": {
-      "id": "openmesh_a42",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-openmesh_a42-squashfs-factory.bin",
-        "openwrt-ipq40xx-generic-openmesh_a42-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Aruba AP-303H": {
-      "id": "aruba_ap-303h",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-aruba_ap-303h-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Netgear EX6100 v2": {
-      "id": "netgear_ex6100v2",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-netgear_ex6100v2-squashfs-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img"
-      ]
-    },
-    "AVM FRITZ!Repeater 1200": {
-      "id": "avm_fritzrepeater-1200",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-avm_fritzrepeater-1200-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Qxwlan E2600AC C2": {
-      "id": "qxwlan_e2600ac-c2",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-qxwlan_e2600ac-c2-squashfs-nand-factory.ubi",
-        "openwrt-ipq40xx-generic-qxwlan_e2600ac-c2-squashfs-nand-sysupgrade.bin"
-      ]
-    },
-    "EnGenius EMD1": {
-      "id": "engenius_emd1",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-engenius_emd1-squashfs-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-engenius_emd1-squashfs-factory.bin"
-      ]
-    },
-    "Compex WPJ428": {
-      "id": "compex_wpj428",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-compex_wpj428-squashfs-sysupgrade.bin"
-      ]
-    },
-    "ASUS RT-AC58U": {
-      "id": "asus_rt-ac58u",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-asus_rt-ac58u-squashfs-sysupgrade.bin"
-      ]
-    },
-    "AVM FRITZ!Box 4040": {
-      "id": "avm_fritzbox-4040",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-avm_fritzbox-4040-squashfs-eva.bin",
-        "openwrt-ipq40xx-generic-avm_fritzbox-4040-squashfs-sysupgrade.bin"
-      ]
-    },
-    "OpenMesh A62": {
-      "id": "openmesh_a62",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-openmesh_a62-squashfs-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-openmesh_a62-squashfs-factory.bin"
-      ]
-    },
-    "Aruba AP-303": {
-      "id": "aruba_ap-303",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-aruba_ap-303-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Qxwlan E2600AC C1": {
-      "id": "qxwlan_e2600ac-c1",
-      "target": "ipq40xx/generic",
-      "images": [
-        "openwrt-ipq40xx-generic-qxwlan_e2600ac-c1-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ramips-rt305x-8devices_carambola-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "8devices Carambola2": {
+      "id": "8dev_carambola2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-8dev_carambola2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
     },
     "8devices Jalapeno": {
       "id": "8dev_jalapeno",
-      "target": "ipq40xx/generic",
       "images": [
-        "openwrt-ipq40xx-generic-8dev_jalapeno-squashfs-nand-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-8dev_jalapeno-squashfs-nand-factory.ubi"
-      ]
+        {
+          "name": "openwrt-ipq40xx-generic-8dev_jalapeno-squashfs-nand-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-8dev_jalapeno-squashfs-nand-factory.ubi"
+        }
+      ],
+      "target": "ipq40xx/generic"
     },
-    "ZyXEL NBG6617": {
-      "id": "zyxel_nbg6617",
-      "target": "ipq40xx/generic",
+    "A5-V11": {
+      "id": "unbranded_a5-v11",
       "images": [
-        "openwrt-ipq40xx-generic-zyxel_nbg6617-squashfs-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-zyxel_nbg6617-squashfs-factory.bin"
-      ]
+        {
+          "name": "openwrt-ramips-rt305x-unbranded_a5-v11-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-unbranded_a5-v11-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "ADB P.DG A4001N": {
+      "id": "A4001N",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-A4001N-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "ADB P.DG A4001N1": {
+      "id": "A4001N1",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-A4001N1-squashfs-cfe.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-A4001N1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "ADB P.DG AV4202N": {
+      "id": "AV4202N",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-AV4202N-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "ADSLR G7": {
+      "id": "adslr_g7",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-adslr_g7-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "AFOUNDRY EW1200": {
+      "id": "afoundry_ew1200",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-afoundry_ew1200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ALFA Network AC1200RM": {
+      "id": "alfa-network_ac1200rm",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-alfa-network_ac1200rm-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
     },
     "ALFA Network AP120C-AC": {
       "id": "alfa-network_ap120c-ac",
-      "target": "ipq40xx/generic",
       "images": [
-        "openwrt-ipq40xx-generic-alfa-network_ap120c-ac-squashfs-nand-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-alfa-network_ap120c-ac-squashfs-nand-factory.bin"
-      ]
+        {
+          "name": "openwrt-ipq40xx-generic-alfa-network_ap120c-ac-squashfs-nand-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-alfa-network_ap120c-ac-squashfs-nand-factory.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
     },
-    "ZyXEL WRE6606": {
-      "id": "zyxel_wre6606",
-      "target": "ipq40xx/generic",
+    "ALFA Network AP121F": {
+      "id": "alfa-network_ap121f",
       "images": [
-        "openwrt-ipq40xx-generic-zyxel_wre6606-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ath79-generic-alfa-network_ap121f-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
     },
-    "EnGenius EAP1300": {
-      "id": "engenius_eap1300",
-      "target": "ipq40xx/generic",
+    "ALFA Network AWUSFREE1": {
+      "id": "alfa-network_awusfree1",
       "images": [
-        "openwrt-ipq40xx-generic-engenius_eap1300-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ramips-mt76x8-alfa-network_awusfree1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
     },
-    "EZVIZ CS-W3-WD1200G EUP": {
-      "id": "ezviz_cs-w3-wd1200g-eup",
-      "target": "ipq40xx/generic",
+    "ALFA Network Quad-E4G": {
+      "id": "alfa-network_quad-e4g",
       "images": [
-        "openwrt-ipq40xx-generic-ezviz_cs-w3-wd1200g-eup-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ramips-mt7621-alfa-network_quad-e4g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
     },
-    "D-Link DAP-2610": {
-      "id": "dlink_dap-2610",
-      "target": "ipq40xx/generic",
+    "ALFA Network R36M-E4G": {
+      "id": "alfa-network_r36m-e4g",
       "images": [
-        "openwrt-ipq40xx-generic-dlink_dap-2610-squashfs-sysupgrade.bin",
-        "openwrt-ipq40xx-generic-dlink_dap-2610-squashfs-factory.bin"
-      ]
+        {
+          "name": "openwrt-ramips-mt7620-alfa-network_r36m-e4g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "ALFA Network Tube-E4G": {
+      "id": "alfa-network_tube-e4g",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-alfa-network_tube-e4g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "ALFA Networks W502U": {
+      "id": "alfa-network_w502u",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-alfa-network_w502u-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "ARC Wireless FreeStation": {
+      "id": "arcwireless_freestation5",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-arcwireless_freestation5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "ASUS Lyra (MAP-AC2200)": {
+      "id": "asus_map-ac2200",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-asus_map-ac2200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "ASUS RT-AC53U": {
+      "id": "asus-rt-ac53u",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-ac53u-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-AC56U": {
+      "id": "asus-rt-ac56u",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-asus-rt-ac56u-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "ASUS RT-AC57U": {
+      "id": "asus_rt-ac57u",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-asus_rt-ac57u-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ASUS RT-AC58U": {
+      "id": "asus_rt-ac58u",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-asus_rt-ac58u-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "ASUS RT-AC65P": {
+      "id": "asus_rt-ac65p",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-asus_rt-ac65p-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-asus_rt-ac65p-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ASUS RT-AC68U": {
+      "id": "asus-rt-ac68u",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-asus-rt-ac68u-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "ASUS RT-AC85P": {
+      "id": "asus_rt-ac85p",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-asus_rt-ac85p-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-asus_rt-ac85p-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ASUS RT-AC87U": {
+      "id": "asus-rt-ac87u",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-asus-rt-ac87u-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "ASUS RT-N10": {
+      "id": "asus-rt-n10",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n10-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N10P v1": {
+      "id": "asus-rt-n10p",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n10p-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N10P v2": {
+      "id": "asus-rt-n10p-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n10p-v2-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N10U A": {
+      "id": "asus-rt-n10u",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n10u-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N10U B": {
+      "id": "asus-rt-n10u-b",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n10u-b-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N12 A1": {
+      "id": "asus-rt-n12",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n12-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N12 B1": {
+      "id": "asus-rt-n12-b1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n12-b1-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N12 C1": {
+      "id": "asus-rt-n12-c1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n12-c1-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N12 D1": {
+      "id": "asus-rt-n12-d1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n12-d1-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N12HP": {
+      "id": "asus-rt-n12hp",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n12hp-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N14UHP": {
+      "id": "asus-rt-n14uhp",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n14uhp-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N15U": {
+      "id": "asus-rt-n15u",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n15u-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N16": {
+      "id": "asus-rt-n16",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n16-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N18U": {
+      "id": "asus-rt-n18u",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-asus-rt-n18u-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "ASUS RT-N53": {
+      "id": "asus-rt-n53",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n53-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N66U": {
+      "id": "asus-rt-n66u",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n66u-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS RT-N66W": {
+      "id": "asus-rt-n66w",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-asus-rt-n66w-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "ASUS WL-300g": {
+      "id": "asus-wl-300g",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-300g-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-320gP": {
+      "id": "asus-wl-320gp",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-320gp-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-330gE": {
+      "id": "asus-wl-330ge",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-330ge-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-500W": {
+      "id": "asus-wl-500w",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-500w-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-500g Deluxe": {
+      "id": "asus-wl-500gd",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-500gd-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-500gP v1": {
+      "id": "asus-wl-500gp-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-500gp-v1-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-500gP v2": {
+      "id": "asus-wl-500gp-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-500gp-v2-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-520gU": {
+      "id": "asus-wl-520gu",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-520gu-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-550gE": {
+      "id": "asus-wl-550ge",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-550ge-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "ASUS WL-HDD25": {
+      "id": "asus-wl-hdd25",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-asus-wl-hdd25-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "AVM FRITZ!Box 3370 Rev. 2 (Hynix NAND)": {
+      "id": "avm_fritz3370-rev2-hynix",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz3370-rev2-hynix-squashfs-eva-kernel.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz3370-rev2-hynix-squashfs-eva-filesystem.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz3370-rev2-hynix-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "AVM FRITZ!Box 3370 Rev. 2 (Micron NAND)": {
+      "id": "avm_fritz3370-rev2-micron",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz3370-rev2-micron-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz3370-rev2-micron-squashfs-eva-kernel.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz3370-rev2-micron-squashfs-eva-filesystem.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "AVM FRITZ!Box 4020": {
+      "id": "avm_fritz4020",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-avm_fritz4020-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "AVM FRITZ!Box 4040": {
+      "id": "avm_fritzbox-4040",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-avm_fritzbox-4040-squashfs-eva.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-avm_fritzbox-4040-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "AVM FRITZ!Box 7312": {
+      "id": "avm_fritz7312",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-avm_fritz7312-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "AVM FRITZ!Box 7320": {
+      "id": "avm_fritz7320",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-avm_fritz7320-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "AVM FRITZ!Box 7360 SL": {
+      "id": "avm_fritz7360sl",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz7360sl-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "AVM FRITZ!Box 7362 SL": {
+      "id": "avm_fritz7362sl",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz7362sl-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "AVM FRITZ!Box 7412": {
+      "id": "avm_fritz7412",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-avm_fritz7412-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
     },
     "AVM FRITZ!Box 7530": {
       "id": "avm_fritzbox-7530",
-      "target": "ipq40xx/generic",
       "images": [
-        "openwrt-ipq40xx-generic-avm_fritzbox-7530-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ipq40xx-generic-avm_fritzbox-7530-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
     },
-    "Unielec U4019 32M": {
-      "id": "unielec_u4019-32m",
-      "target": "ipq40xx/generic",
+    "AVM FRITZ!Repeater 1200": {
+      "id": "avm_fritzrepeater-1200",
       "images": [
-        "openwrt-ipq40xx-generic-unielec_u4019-32m-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ipq40xx-generic-avm_fritzrepeater-1200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "AVM FRITZ!Repeater 3000": {
+      "id": "avm_fritzrepeater-3000",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-avm_fritzrepeater-3000-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "AVM FRITZ!WLAN Repeater 300E": {
+      "id": "avm_fritz300e",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-avm_fritz300e-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "AXIMCom MR-102N": {
+      "id": "aximcom_mr-102n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-aximcom_mr-102n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Accton WR6202": {
+      "id": "accton_wr6202",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-accton_wr6202-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Actiontec R1000H": {
+      "id": "R1000H",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-R1000H-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Adtran/Bluesocket BSAP-1800 v2": {
+      "id": "adtran_bsap1800-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-adtran_bsap1800-v2-squashfs-kernel.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-adtran_bsap1800-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-adtran_bsap1800-v2-squashfs-rootfs.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Adtran/Bluesocket BSAP-1840": {
+      "id": "adtran_bsap1840",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-adtran_bsap1840-squashfs-kernel.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-adtran_bsap1840-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-adtran_bsap1840-squashfs-rootfs.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Aerohive HiveAP 121": {
+      "id": "aerohive_hiveap-121",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-aerohive_hiveap-121-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-nand-aerohive_hiveap-121-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "Aerohive HiveAP-330": {
+      "id": "aerohive_hiveap-330",
+      "images": [
+        {
+          "name": "openwrt-mpc85xx-p1020-aerohive_hiveap-330-squashfs-fdt.bin"
+        },
+        {
+          "name": "openwrt-mpc85xx-p1020-aerohive_hiveap-330-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mpc85xx/p1020"
+    },
+    "Aigale Ai-BR100": {
+      "id": "aigale_ai-br100",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-aigale_ai-br100-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "AirLive Air3GII": {
+      "id": "airlive_air3gii",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-airlive_air3gii-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Airlink AR670W": {
+      "id": "airlink101_ar670w",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt288x-airlink101_ar670w-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt288x-airlink101_ar670w-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt288x"
+    },
+    "Airlink AR725W": {
+      "id": "airlink101_ar725w",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt288x-airlink101_ar725w-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt288x"
+    },
+    "Akition myCloud mini": {
+      "id": "akitio_mycloud",
+      "images": [
+        {
+          "name": "openwrt-oxnas-ox820-akitio_mycloud-ubifs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-akitio_mycloud-ubifs-sysupgrade.tar"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-akitio_mycloud-squashfs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-akitio_mycloud-squashfs-sysupgrade.tar"
+        }
+      ],
+      "target": "oxnas/ox820"
+    },
+    "Alcatel RG100A": {
+      "id": "RG100A",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-RG100A-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Alice/O2 IAD 4421": {
+      "id": "arcadyan_arv7506pw11",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv7506pw11-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Allnet ALL0239-3G": {
+      "id": "aztech_hw550-3g",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-aztech_hw550-3g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Allnet ALL0256N 4M": {
+      "id": "allnet_all0256n-4m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-allnet_all0256n-4m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Allnet ALL0256N 8M": {
+      "id": "allnet_all0256n-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-allnet_all0256n-8m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Allnet ALL0333CJ": {
+      "id": "allnet_all0333cj",
+      "images": [
+        {
+          "name": "openwrt-lantiq-ase-allnet_all0333cj-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/ase"
+    },
+    "Allnet ALL5002": {
+      "id": "allnet_all5002",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-allnet_all5002-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Allnet ALL5003": {
+      "id": "allnet_all5003",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-allnet_all5003-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Alpha ASL26555": {
+      "id": "alphanetworks_asl26555-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-alphanetworks_asl26555-8m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Alpha ASL26555 16M": {
+      "id": "alphanetworks_asl26555-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-alphanetworks_asl26555-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Alpha ASL56026": {
+      "id": "alphanetworks_asl56026",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-alphanetworks_asl56026-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Arcadyan ARV4510PW": {
+      "id": "arcadyan_arv4510pw",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv4510pw-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Arcadyan ARV7506PW11": {
+      "id": "arcadyan_arv7506pw11",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv7506pw11-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Arcadyan ARV7510PW22": {
+      "id": "arcadyan_arv7510pw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv7510pw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Arcadyan ARV7518PW": {
+      "id": "arcadyan_arv7518pw",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv7518pw-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Arcadyan ARV7519PW": {
+      "id": "arcadyan_arv7519pw",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv7519pw-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Arcadyan ARV7519RW22": {
+      "id": "arcadyan_arv7519rw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_arv7519rw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Arcadyan ARV752DPW": {
+      "id": "arcadyan_arv752dpw",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv752dpw-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Arcadyan ARV752DPW22": {
+      "id": "arcadyan_arv752dpw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv752dpw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Arcadyan ARV8539PW22": {
+      "id": "arcadyan_arv8539pw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv8539pw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Arcadyan VGV7510KW22 BRN": {
+      "id": "arcadyan_vgv7510kw22-brn",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vgv7510kw22-brn-squashfs-factory.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Arcadyan VGV7510KW22 NOR": {
+      "id": "arcadyan_vgv7510kw22-nor",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vgv7510kw22-nor-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Arcadyan VGV7519 BRN": {
+      "id": "arcadyan_vgv7519-brn",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vgv7519-brn-squashfs-factory.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Arcadyan VGV7519 NOR": {
+      "id": "arcadyan_vgv7519-nor",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vgv7519-nor-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Argus ATP-52B": {
+      "id": "argus_atp-52b",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-argus_atp-52b-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Aruba AP-105": {
+      "id": "aruba_ap-105",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-aruba_ap-105-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Aruba AP-303": {
+      "id": "aruba_ap-303",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-aruba_ap-303-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Aruba AP-303H": {
+      "id": "aruba_ap-303h",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-aruba_ap-303h-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "AsiaRF AP7621-001": {
+      "id": "asiarf_ap7621-001",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-asiarf_ap7621-001-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "AsiaRF AP7621-NV1": {
+      "id": "asiarf_ap7621-nv1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-asiarf_ap7621-nv1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "AsiaRF AWAPN2403": {
+      "id": "asiarf_awapn2403",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-asiarf_awapn2403-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "AsiaRF AWM002-EVB 4M": {
+      "id": "asiarf_awm002-evb-4m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-asiarf_awm002-evb-4m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "AsiaRF AWM002-EVB/AWM003-EVB 8M": {
+      "id": "asiarf_awm002-evb-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-asiarf_awm002-evb-8m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Astoria Networks ARV7510PW22": {
+      "id": "arcadyan_arv7510pw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv7510pw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Astoria Networks ARV7518PW": {
+      "id": "arcadyan_arv7518pw",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv7518pw-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Astoria Networks ARV7519PW": {
+      "id": "arcadyan_arv7519pw",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv7519pw-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Astoria Networks ARV7519RW22": {
+      "id": "arcadyan_arv7519rw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_arv7519rw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Asus RP-N53": {
+      "id": "asus_rp-n53",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-asus_rp-n53-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Asus RT-AC51U": {
+      "id": "asus_rt-ac51u",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-asus_rt-ac51u-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Asus RT-G32 B1": {
+      "id": "asus_rt-g32-b1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-asus_rt-g32-b1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Asus RT-N10+": {
+      "id": "asus_rt-n10-plus",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-asus_rt-n10-plus-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Asus RT-N11P/RT-N12+/RT-N12Eb1": {
+      "id": "asus_rt-n12p",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-asus_rt-n12p-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Asus RT-N13U": {
+      "id": "asus_rt-n13u",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-asus_rt-n13u-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Asus RT-N14u": {
+      "id": "asus_rt-n14u",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-asus_rt-n14u-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Asus RT-N15": {
+      "id": "asus_rt-n15",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt288x-asus_rt-n15-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt288x"
+    },
+    "Asus RT-N56U": {
+      "id": "asus_rt-n56u",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-asus_rt-n56u-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "Asus WL-330N": {
+      "id": "asus_wl-330n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-asus_wl-330n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Asus WL-330N3G": {
+      "id": "asus_wl-330n3g",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-asus_wl-330n3g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Atheros Generic AR2xxx board": {
+      "id": "generic",
+      "images": [
+        {
+          "name": "openwrt-ath25-generic-kernel.elf"
+        },
+        {
+          "name": "openwrt-ath25-generic-squashfs-rootfs.bin"
+        },
+        {
+          "name": "openwrt-ath25-generic-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath25-generic-kernel.gz"
+        },
+        {
+          "name": "openwrt-ath25-generic-kernel.lzma"
+        }
+      ],
+      "target": "ath25/"
+    },
+    "Atmel AT91SAM9263-EK": {
+      "id": "at91sam9263ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9263ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9263ek-ubifs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9263ek-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9263ek-squashfs-zImage"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Atmel AT91SAM9G15-EK": {
+      "id": "at91sam9g15ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g15ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g15ek-squashfs-root.ubi"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Atmel AT91SAM9G20-EK": {
+      "id": "at91sam9g20ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g20ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g20ek-ubifs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g20ek-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g20ek-squashfs-zImage"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Atmel AT91SAM9G20-EK 2MMC": {
+      "id": "at91sam9g20ek_2mmc",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g20ek_2mmc-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g20ek_2mmc-ubifs-root.ubi"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Atmel AT91SAM9G25-EK": {
+      "id": "at91sam9g25ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g25ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g25ek-squashfs-root.ubi"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Atmel AT91SAM9G35-EK": {
+      "id": "at91sam9g35ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g35ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9g35ek-squashfs-root.ubi"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Atmel AT91SAM9M10G45-EK": {
+      "id": "at91sam9m10g45ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9m10g45ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9m10g45ek-squashfs-root.ubi"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Atmel AT91SAM9X25-EK": {
+      "id": "at91sam9x25ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x25ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x25ek-ubifs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x25ek-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x25ek-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x25ek-squashfs-zImage"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Atmel AT91SAM9X35-EK": {
+      "id": "at91sam9x35ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x35ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x35ek-ubifs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x35ek-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x35ek-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-at91sam9x35ek-squashfs-zImage"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "AudioCodes MediaPack MP-252": {
+      "id": "audiocodes_mp-252",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-audiocodes_mp-252-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Avnet ZedBoard": {
+      "id": "avnet_zynq-zed",
+      "images": [
+        {
+          "name": "openwrt-zynq-avnet_zynq-zed-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "zynq/"
+    },
+    "Aztech HW550-3G": {
+      "id": "aztech_hw550-3g",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-aztech_hw550-3g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "BDCOM WAP2100-SK (ZTE ZXECS EBG3130)": {
+      "id": "bdcom_wap2100-sk",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-bdcom_wap2100-sk-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "BT Home Hub 2.0 A": {
+      "id": "HomeHub2A",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-HomeHub2A-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "BT Openreach ECI VDSL Modem V-2FUb/I": {
+      "id": "alphanetworks_asl56026",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-alphanetworks_asl56026-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "BT Openreach ECI VDSL Modem V-2FUb/R": {
+      "id": "arcadyan_vg3503j",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vg3503j-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "BeagleBoard.org OMAP3 TI beagleboard": {
+      "id": "ti_omap3-beagle",
+      "images": [
+        {
+          "name": "openwrt-omap-ti_omap3-beagle-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-omap-ti_omap3-beagle-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "omap/"
+    },
+    "Belkin F5D8235 V1": {
+      "id": "belkin_f5d8235-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt288x-belkin_f5d8235-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt288x"
+    },
+    "Belkin F5D8235 v2": {
+      "id": "belkin_f5d8235-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-belkin_f5d8235-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Belkin F7C027": {
+      "id": "belkin_f7c027",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-belkin_f7c027-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Belkin F9K1109 Version 1.0": {
+      "id": "belkin_f9k1109v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-belkin_f9k1109v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "British Telecom Home Hub 2 Type B": {
+      "id": "bt_homehub-v2b",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-bt_homehub-v2b-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "British Telecom Home Hub 3 Type A": {
+      "id": "bt_homehub-v3a",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-bt_homehub-v3a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "British Telecom Home Hub 5 Type A": {
+      "id": "bt_homehub-v5a",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-bt_homehub-v5a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Buffalo BHR-4GRV": {
+      "id": "buffalo_bhr-4grv",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-buffalo_bhr-4grv-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Buffalo BHR-4GRV2": {
+      "id": "buffalo_bhr-4grv2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-buffalo_bhr-4grv2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Buffalo WBMR-300HPD": {
+      "id": "buffalo_wbmr-300hpd",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-buffalo_wbmr-300hpd-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Buffalo WBMR-HP-G300H A": {
+      "id": "buffalo_wbmr-hp-g300h-a",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-buffalo_wbmr-hp-g300h-a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Buffalo WBMR-HP-G300H B": {
+      "id": "buffalo_wbmr-hp-g300h-b",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-buffalo_wbmr-hp-g300h-b-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Buffalo WCR-1166DS": {
+      "id": "buffalo_wcr-1166ds",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-buffalo_wcr-1166ds-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-buffalo_wcr-1166ds-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Buffalo WHR-1166D": {
+      "id": "buffalo_whr-1166d",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-buffalo_whr-1166d-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Buffalo WHR-300HP2": {
+      "id": "buffalo_whr-300hp2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-buffalo_whr-300hp2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Buffalo WHR-600D": {
+      "id": "buffalo_whr-600d",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-buffalo_whr-600d-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Buffalo WHR-G300N": {
+      "id": "buffalo_whr-g300n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-buffalo_whr-g300n-squashfs-tftp.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-buffalo_whr-g300n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Buffalo WHR-G301N": {
+      "id": "buffalo_whr-g301n",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-buffalo_whr-g301n-squashfs-tftp.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-buffalo_whr-g301n-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-buffalo_whr-g301n-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "Buffalo WLI-TX4-AG300N": {
+      "id": "buffalo_wli-tx4-ag300n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt288x-buffalo_wli-tx4-ag300n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt288x"
+    },
+    "Buffalo WMR-300": {
+      "id": "buffalo_wmr-300",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-buffalo_wmr-300-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Buffalo WSR-1166DHP": {
+      "id": "buffalo_wsr-1166dhp",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-buffalo_wsr-1166dhp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Buffalo WSR-600DHP": {
+      "id": "buffalo_wsr-600dhp",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-buffalo_wsr-600dhp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Buffalo WXR-1900DHP": {
+      "id": "buffalo-wxr-1900dhp",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-buffalo-wxr-1900dhp-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "Buffalo WXR-2533DHP": {
+      "id": "buffalo_wxr-2533dhp",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-buffalo_wxr-2533dhp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "Buffalo WZR-1750DHP": {
+      "id": "buffalo-wzr-1750dhp",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-buffalo-wzr-1750dhp-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "Buffalo WZR-600DHP2": {
+      "id": "buffalo-wzr-600dhp2",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-buffalo-wzr-600dhp2-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "Buffalo WZR-900DHP": {
+      "id": "buffalo-wzr-900dhp",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-buffalo-wzr-900dhp-squashfs.trx"
+        },
+        {
+          "name": "openwrt-bcm53xx-generic-buffalo-wzr-900dhp-squashfs.factory-DHP-EU.bin"
+        },
+        {
+          "name": "openwrt-bcm53xx-generic-buffalo-wzr-900dhp-squashfs.factory-DHP2-JP.bin"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "Buffalo WZR-AGL300NH": {
+      "id": "buffalo_wzr-agl300nh",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt288x-buffalo_wzr-agl300nh-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt288x"
+    },
+    "Buffalo WZR-HP-AG300H": {
+      "id": "buffalo_wzr-hp-ag300h",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-ag300h-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-ag300h-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-ag300h-squashfs-tftp.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Buffalo WZR-HP-G302H A1A0": {
+      "id": "buffalo_wzr-hp-g302h-a1a0",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-g302h-a1a0-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-g302h-a1a0-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-g302h-a1a0-squashfs-tftp.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Buffalo WZR-HP-G450H/WZR-450HP": {
+      "id": "buffalo_wzr-hp-g450h",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-g450h-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-g450h-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-buffalo_wzr-hp-g450h-squashfs-tftp.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "COMFAST CF-E110N v2": {
+      "id": "comfast_cf-e110n-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-comfast_cf-e110n-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "COMFAST CF-E120A v3": {
+      "id": "comfast_cf-e120a-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-comfast_cf-e120a-v3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "COMFAST CF-E313AC": {
+      "id": "comfast_cf-e313ac",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-comfast_cf-e313ac-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "COMFAST CF-E314N v2": {
+      "id": "comfast_cf-e314n-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-comfast_cf-e314n-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "COMFAST CF-E5/E7": {
+      "id": "comfast_cf-e5",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-comfast_cf-e5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "COMFAST CF-WR650AC v1": {
+      "id": "comfast_cf-wr650ac-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-comfast_cf-wr650ac-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "COMFAST CF-WR650AC v2": {
+      "id": "comfast_cf-wr650ac-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-comfast_cf-wr650ac-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "CZ.NIC Turris Omnia": {
+      "id": "cznic_turris-omnia",
+      "images": [
+        {
+          "name": "omnia-medkit-openwrt-mvebu-cortexa9-cznic_turris-omnia-initramfs.tar.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-cznic_turris-omnia-sysupgrade.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "CalAmp LMU5000": {
+      "id": "lmu5000",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-lmu5000-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-at91-sam9x-lmu5000-ubifs-factory.bin"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Calao TNYA9260": {
+      "id": "tny_a9260",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-tny_a9260-ubifs-factory.bin"
+        },
+        {
+          "name": "openwrt-at91-sam9x-tny_a9260-squashfs-factory.bin"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Calao TNYA9263": {
+      "id": "tny_a9263",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-tny_a9263-ubifs-factory.bin"
+        },
+        {
+          "name": "openwrt-at91-sam9x-tny_a9263-squashfs-factory.bin"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Calao TNYA9G20": {
+      "id": "tny_a9g20",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-tny_a9g20-ubifs-factory.bin"
+        },
+        {
+          "name": "openwrt-at91-sam9x-tny_a9g20-squashfs-factory.bin"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Calao USBA9260": {
+      "id": "usb_a9260",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-usb_a9260-ubifs-factory.bin"
+        },
+        {
+          "name": "openwrt-at91-sam9x-usb_a9260-squashfs-factory.bin"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Calao USBA9263": {
+      "id": "usb_a9263",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-usb_a9263-ubifs-factory.bin"
+        },
+        {
+          "name": "openwrt-at91-sam9x-usb_a9263-squashfs-factory.bin"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Calao USBA9G20": {
+      "id": "usb_a9g20",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-usb_a9g20-ubifs-factory.bin"
+        },
+        {
+          "name": "openwrt-at91-sam9x-usb_a9g20-squashfs-factory.bin"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Cisco Meraki MR24": {
+      "id": "meraki_mr24",
+      "images": [
+        {
+          "name": "openwrt-apm821xx-nand-meraki_mr24-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "apm821xx/nand"
+    },
+    "Cisco Meraki MR33": {
+      "id": "meraki_mr33",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-meraki_mr33-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Cisco Meraki MX60/MX60W": {
+      "id": "meraki_mx60",
+      "images": [
+        {
+          "name": "openwrt-apm821xx-nand-meraki_mx60-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "apm821xx/nand"
     },
     "Cisco Systems ON100": {
       "id": "cisco_on100",
-      "target": "kirkwood",
       "images": [
-        "openwrt-kirkwood-cisco_on100-squashfs-sysupgrade.bin",
-        "openwrt-kirkwood-cisco_on100-squashfs-factory.bin"
-      ]
+        {
+          "name": "openwrt-kirkwood-cisco_on100-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-cisco_on100-squashfs-factory.bin"
+        }
+      ],
+      "target": "kirkwood/"
     },
-    "Linksys EA3500 (Audi)": {
-      "id": "linksys_audi",
-      "target": "kirkwood",
+    "Cloud Engines PogoPlug Pro (with mPCIe)": {
+      "id": "cloudengines_pogoplugpro",
       "images": [
-        "openwrt-kirkwood-linksys_audi-squashfs-factory.bin",
-        "openwrt-kirkwood-linksys_audi-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-oxnas-ox820-cloudengines_pogoplugpro-ubifs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-cloudengines_pogoplugpro-ubifs-sysupgrade.tar"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-cloudengines_pogoplugpro-squashfs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-cloudengines_pogoplugpro-squashfs-sysupgrade.tar"
+        }
+      ],
+      "target": "oxnas/ox820"
     },
-    "Cloud Engines Pogoplug V4": {
-      "id": "cloudengines_pogoplugv4",
-      "target": "kirkwood",
+    "Cloud Engines PogoPlug Series V3 (without mPCIe)": {
+      "id": "cloudengines_pogoplug-series-3",
       "images": [
-        "openwrt-kirkwood-cloudengines_pogoplugv4-squashfs-factory.bin",
-        "openwrt-kirkwood-cloudengines_pogoplugv4-squashfs-sysupgrade.bin"
-      ]
-    },
-    "RaidSonic ICY BOX IB-NAS62x0": {
-      "id": "raidsonic_ib-nas62x0",
-      "target": "kirkwood",
-      "images": [
-        "openwrt-kirkwood-raidsonic_ib-nas62x0-squashfs-factory.bin",
-        "openwrt-kirkwood-raidsonic_ib-nas62x0-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Seagate GoFlexNet": {
-      "id": "seagate_goflexnet",
-      "target": "kirkwood",
-      "images": [
-        "openwrt-kirkwood-seagate_goflexnet-squashfs-factory.bin",
-        "openwrt-kirkwood-seagate_goflexnet-squashfs-sysupgrade.bin"
-      ]
-    },
-    "Iomega StorCenter ix2-200": {
-      "id": "iom_ix2_200",
-      "target": "kirkwood",
-      "images": [
-        "openwrt-kirkwood-iom_ix2_200-squashfs-factory.bin",
-        "openwrt-kirkwood-iom_ix2_200-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-oxnas-ox820-cloudengines_pogoplug-series-3-ubifs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-cloudengines_pogoplug-series-3-ubifs-sysupgrade.tar"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-cloudengines_pogoplug-series-3-squashfs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-cloudengines_pogoplug-series-3-squashfs-sysupgrade.tar"
+        }
+      ],
+      "target": "oxnas/ox820"
     },
     "Cloud Engines Pogoplug E02": {
       "id": "cloudengines_pogoe02",
-      "target": "kirkwood",
       "images": [
-        "openwrt-kirkwood-cloudengines_pogoe02-squashfs-factory.bin",
-        "openwrt-kirkwood-cloudengines_pogoe02-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-kirkwood-cloudengines_pogoe02-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-cloudengines_pogoe02-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
     },
-    "Linksys E4200v2 / EA4500 (Viper)": {
-      "id": "linksys_viper",
-      "target": "kirkwood",
+    "Cloud Engines Pogoplug V4": {
+      "id": "cloudengines_pogoplugv4",
       "images": [
-        "openwrt-kirkwood-linksys_viper-squashfs-factory.bin",
-        "openwrt-kirkwood-linksys_viper-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-kirkwood-cloudengines_pogoplugv4-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-cloudengines_pogoplugv4-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
     },
-    "ZyXEL NSA310b": {
-      "id": "zyxel_nsa310b",
-      "target": "kirkwood",
+    "Comfast CF-WR800N": {
+      "id": "comfast_cf-wr800n",
       "images": [
-        "openwrt-kirkwood-zyxel_nsa310b-squashfs-factory.bin",
-        "openwrt-kirkwood-zyxel_nsa310b-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-ramips-mt7620-comfast_cf-wr800n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Compex WPJ419": {
+      "id": "compex_wpj419",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-compex_wpj419-squashfs-nand-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-compex_wpj419-squashfs-nand-factory.ubi"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Compex WPJ428": {
+      "id": "compex_wpj428",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-compex_wpj428-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Compex WPQ864": {
+      "id": "compex_wpq864",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-compex_wpq864-squashfs-nand-factory.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-compex_wpq864-squashfs-nand-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "CompuLab TrimSlice": {
+      "id": "compulab_trimslice",
+      "images": [
+        {
+          "name": "openwrt-tegra-compulab_trimslice-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-tegra-compulab_trimslice-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "tegra/"
+    },
+    "Comtrend AR-5315u": {
+      "id": "AR5315u",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-AR5315u-squashfs-cfe.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-AR5315u-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Comtrend AR-5381u": {
+      "id": "AR5381u",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-AR5381u-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-AR5381u-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Comtrend AR-5387un": {
+      "id": "AR5387un",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-AR5387un-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-AR5387un-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Comtrend CT-6373": {
+      "id": "CT-6373",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-CT-6373-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Comtrend VR-3025u": {
+      "id": "VR-3025u",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-VR-3025u-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-VR-3025u-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Comtrend VR-3025un": {
+      "id": "VR-3025un",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-VR-3025un-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Comtrend VR-3026e": {
+      "id": "VR-3026e",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-VR-3026e-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Comtrend WAP-5813n": {
+      "id": "WAP-5813n",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-WAP-5813n-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "CreativeBox v1": {
+      "id": "xzwifi_creativebox-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-xzwifi_creativebox-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Crisis Innovation Lab MeshPoint.One": {
+      "id": "cilab_meshpoint-one",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-cilab_meshpoint-one-squashfs-nand-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-cilab_meshpoint-one-squashfs-nand-factory.ubi"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Cubietech Cubieboard": {
+      "id": "cubietech_a10-cubieboard",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa8-cubietech_a10-cubieboard-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa8-cubietech_a10-cubieboard-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa8"
+    },
+    "Cubietech Cubieboard2": {
+      "id": "cubietech_cubieboard2",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-cubietech_cubieboard2-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-cubietech_cubieboard2-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Cubietech Cubietruck": {
+      "id": "cubietech_cubietruck",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-cubietech_cubietruck-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-cubietech_cubietruck-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Cudy WR1000": {
+      "id": "cudy_wr1000",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-cudy_wr1000-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-cudy_wr1000-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "D-Link DAP-1350": {
+      "id": "dlink_dap-1350",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dap-1350-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dap-1350-squashfs-factory-NA.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dap-1350-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DAP-1522 A1": {
+      "id": "dlink_dap-1522-a1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt288x-dlink_dap-1522-a1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt288x-dlink_dap-1522-a1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt288x"
+    },
+    "D-Link DAP-2610": {
+      "id": "dlink_dap-2610",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-dlink_dap-2610-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-dlink_dap-2610-squashfs-factory.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "D-Link DCH-M225": {
+      "id": "dlink_dch-m225",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dch-m225-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dch-m225-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "D-Link DIR-300 B1": {
+      "id": "dlink_dir-300-b1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-300-b1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-300-b1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-300 B7": {
+      "id": "dlink_dir-300-b7",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-300-b7-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-320 B1": {
+      "id": "dlink_dir-320-b1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-320-b1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-505": {
+      "id": "dlink_dir-505",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-505-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "D-Link DIR-510L": {
+      "id": "dlink_dir-510l",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dir-510l-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dir-510l-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "D-Link DIR-600 B1/B2": {
+      "id": "dlink_dir-600-b1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-600-b1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-600-b1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-610 A1": {
+      "id": "dlink_dir-610-a1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-610-a1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-610-a1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-615 D": {
+      "id": "dlink_dir-615-d",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-615-d-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-615-d-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-615 H1": {
+      "id": "dlink_dir-615-h1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-615-h1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-615-h1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-620 A1": {
+      "id": "dlink_dir-620-a1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-620-a1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-620 D1": {
+      "id": "dlink_dir-620-d1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dir-620-d1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DIR-645": {
+      "id": "dlink_dir-645",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-dlink_dir-645-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt3883-dlink_dir-645-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "D-Link DIR-685 Xtreme N Storage Router": {
+      "id": "dlink_dir-685",
+      "images": [
+        {
+          "name": "openwrt-gemini-dlink_dir-685-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-gemini-dlink_dir-685-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "gemini/"
+    },
+    "D-Link DIR-810L": {
+      "id": "dlink_dir-810l",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dir-810l-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "D-Link DIR-825 B1": {
+      "id": "dlink_dir-825-b1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-825-b1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "D-Link DIR-825 C1": {
+      "id": "dlink_dir-825-c1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-825-c1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-825-c1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "D-Link DIR-835 A1": {
+      "id": "dlink_dir-835-a1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-835-a1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-835-a1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "D-Link DIR-842 C1": {
+      "id": "dlink_dir-842-c1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-842-c1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-842-c1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "D-Link DIR-842 C2": {
+      "id": "dlink_dir-842-c2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-842-c2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-842-c2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "D-Link DIR-842 C3": {
+      "id": "dlink_dir-842-c3",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-842-c3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-842-c3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "D-Link DIR-859 A1": {
+      "id": "dlink_dir-859-a1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-859-a1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-dlink_dir-859-a1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "D-Link DIR-860L B1": {
+      "id": "dlink_dir-860l-b1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-dlink_dir-860l-b1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-dlink_dir-860l-b1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "D-Link DIR-885L": {
+      "id": "dlink-dir-885l",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-dlink-dir-885l-squashfs.bin"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "D-Link DNS-313 1-Bay Network Storage Enclosure": {
+      "id": "dlink_dns-313",
+      "images": [
+        {
+          "name": "openwrt-gemini-dlink_dns-313-ext4-factory.bin.gz"
+        }
+      ],
+      "target": "gemini/"
+    },
+    "D-Link DSL-2650U": {
+      "id": "DSL2650U",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL2650U-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DSL-2740B C2": {
+      "id": "DSL274XB-C2",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL274XB-C2-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DSL-2740B C3": {
+      "id": "DSL274XB-C3",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL274XB-C3-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DSL-2740B F1": {
+      "id": "DSL274XB-F1",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL274XB-F1-squashfs-cfe-EU.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-DSL274XB-F1-squashfs-cfe-AU.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DSL-2741B C2": {
+      "id": "DSL274XB-C2",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL274XB-C2-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DSL-2741B C3": {
+      "id": "DSL274XB-C3",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL274XB-C3-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DSL-2741B F1": {
+      "id": "DSL274XB-F1",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL274XB-F1-squashfs-cfe-EU.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-DSL274XB-F1-squashfs-cfe-AU.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DSL-2750B D1": {
+      "id": "DSL275XB-D1",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL275XB-D1-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DSL-2751 D1": {
+      "id": "DSL275XB-D1",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DSL275XB-D1-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DVA-G3810BN/TL": {
+      "id": "DVAG3810BN",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DVAG3810BN-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "D-Link DWL-3150": {
+      "id": "dlink-dwl-3150",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-dlink-dwl-3150-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "D-Link DWR-116 A1/A2": {
+      "id": "dlink_dwr-116-a1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-116-a1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-116-a1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "D-Link DWR-118 A1": {
+      "id": "dlink_dwr-118-a1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-118-a1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-118-a1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "D-Link DWR-118 A2": {
+      "id": "dlink_dwr-118-a2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-118-a2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-118-a2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "D-Link DWR-512 B": {
+      "id": "dlink_dwr-512-b",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dwr-512-b-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-dlink_dwr-512-b-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "D-Link DWR-921 C1": {
+      "id": "dlink_dwr-921-c1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-921-c1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-921-c1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "D-Link DWR-921 C3": {
+      "id": "dlink_dwr-921-c3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-921-c3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-921-c3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "D-Link DWR-922 E2": {
+      "id": "dlink_dwr-922-e2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-922-e2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-dlink_dwr-922-e2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Digilent Zybo": {
+      "id": "digilent_zynq-zybo",
+      "images": [
+        {
+          "name": "openwrt-zynq-digilent_zynq-zybo-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "zynq/"
+    },
+    "Digilent Zybo Z7": {
+      "id": "digilent_zynq-zybo-z7",
+      "images": [
+        {
+          "name": "openwrt-zynq-digilent_zynq-zybo-z7-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "zynq/"
+    },
+    "Dovado Tiny AC": {
+      "id": "dovado_tiny-ac",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-dovado_tiny-ac-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "DuZun DM06": {
+      "id": "duzun_dm06",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-duzun_dm06-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "ELECOM WRC-1167GHBK2-S": {
+      "id": "elecom_wrc-1167ghbk2-s",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-elecom_wrc-1167ghbk2-s-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-elecom_wrc-1167ghbk2-s-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ELECOM WRC-1750GHBK2-I/C": {
+      "id": "elecom_wrc-1750ghbk2-i",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-elecom_wrc-1750ghbk2-i-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "ELECOM WRC-1900GST": {
+      "id": "elecom_wrc-1900gst",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-elecom_wrc-1900gst-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-elecom_wrc-1900gst-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ELECOM WRC-2533GST": {
+      "id": "elecom_wrc-2533gst",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-elecom_wrc-2533gst-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-elecom_wrc-2533gst-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ELECOM WRC-300GHBK2-I": {
+      "id": "elecom_wrc-300ghbk2-i",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-elecom_wrc-300ghbk2-i-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "EZVIZ CS-W3-WD1200G EUP": {
+      "id": "ezviz_cs-w3-wd1200g-eup",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-ezviz_cs-w3-wd1200g-eup-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "EasyAcc WIZARD 8800": {
+      "id": "easyacc_wizard-8800",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-easyacc_wizard-8800-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Edimax 3g-6200n": {
+      "id": "edimax_3g-6200n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-edimax_3g-6200n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Edimax 3g-6200nl": {
+      "id": "edimax_3g-6200nl",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-edimax_3g-6200nl-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Edimax BR-6475nD": {
+      "id": "edimax_br-6475nd",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-edimax_br-6475nd-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "Edimax BR-6478AC V2": {
+      "id": "edimax_br-6478ac-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-edimax_br-6478ac-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Edimax EW-7476RPC": {
+      "id": "edimax_ew-7476rpc",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-edimax_ew-7476rpc-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Edimax EW-7478AC": {
+      "id": "edimax_ew-7478ac",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-edimax_ew-7478ac-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Edimax EW-7478APC": {
+      "id": "edimax_ew-7478apc",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-edimax_ew-7478apc-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Edimax Gemini AC2600 RG21S": {
+      "id": "edimax_rg21s",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-edimax_rg21s-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Edimax Gemini RA21S": {
+      "id": "edimax_ra21s",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-edimax_ra21s-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-edimax_ra21s-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Edimax PS-1208MFg": {
+      "id": "edimax-ps1208-mfg",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-edimax-ps1208-mfg-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Edimax RA21S": {
+      "id": "edimax_ra21s",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-edimax_ra21s-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-edimax_ra21s-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Elecom WRH-300CR": {
+      "id": "elecom_wrh-300cr",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-elecom_wrh-300cr-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-elecom_wrh-300cr-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Embedded Wireless Dorin": {
+      "id": "embeddedwireless_dorin",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-embeddedwireless_dorin-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "EnGenius EAP1300": {
+      "id": "engenius_eap1300",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-engenius_eap1300-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "EnGenius ECB1750": {
+      "id": "engenius_ecb1750",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-engenius_ecb1750-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "EnGenius EMD1": {
+      "id": "engenius_emd1",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-engenius_emd1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-engenius_emd1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "EnGenius ENS620EXT": {
+      "id": "engenius_ens620ext",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-engenius_ens620ext-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-engenius_ens620ext-squashfs-factory_30.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-engenius_ens620ext-squashfs-factory_35.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "EnGenius EPG5000": {
+      "id": "engenius_epg5000",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-engenius_epg5000-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-engenius_epg5000-squashfs-factory.dlf"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "EnGenius ESR-9753": {
+      "id": "engenius_esr-9753",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-engenius_esr-9753-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "EnGenius ESR600": {
+      "id": "engenius_esr600",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-engenius_esr600-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-engenius_esr600-squashfs-factory.dlf"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "EnGenius EWS511AP": {
+      "id": "engenius_ews511ap",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-engenius_ews511ap-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Enterasys WS-AP3710i": {
+      "id": "enterasys_ws-ap3710i",
+      "images": [
+        {
+          "name": "openwrt-mpc85xx-p1020-enterasys_ws-ap3710i-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mpc85xx/p1020"
+    },
+    "Firefly FireWRT": {
+      "id": "firefly_firewrt",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-firefly_firewrt-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Fon FON2601": {
+      "id": "fon_fon2601",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-fon_fon2601-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Fon Fonera 2.0N": {
+      "id": "fon_fonera-20n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-fon_fonera-20n-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-fon_fonera-20n-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Freescale P2020RDB": {
+      "id": "freescale_p2020rdb",
+      "images": [
+        {
+          "name": "openwrt-mpc85xx-p2020-freescale_p2020rdb-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mpc85xx/p2020"
+    },
+    "FriendlyARM NanoPi M1 Plus": {
+      "id": "friendlyarm_nanopi-m1-plus",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-friendlyarm_nanopi-m1-plus-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-friendlyarm_nanopi-m1-plus-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "FriendlyARM NanoPi NEO": {
+      "id": "friendlyarm_nanopi-neo",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-friendlyarm_nanopi-neo-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-friendlyarm_nanopi-neo-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "FriendlyARM NanoPi NEO Air": {
+      "id": "friendlyarm_nanopi-neo-air",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-friendlyarm_nanopi-neo-air-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-friendlyarm_nanopi-neo-air-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "FriendlyARM NanoPi NEO Plus2": {
+      "id": "friendlyarm_nanopi-neo-plus2",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa53-friendlyarm_nanopi-neo-plus2-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa53-friendlyarm_nanopi-neo-plus2-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa53"
+    },
+    "FriendlyARM NanoPi NEO2": {
+      "id": "friendlyarm_nanopi-neo2",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa53-friendlyarm_nanopi-neo2-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa53-friendlyarm_nanopi-neo2-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa53"
+    },
+    "GL.iNet GL-AR150": {
+      "id": "glinet_gl-ar150",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-glinet_gl-ar150-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "GL.iNet GL-AR300M Lite": {
+      "id": "glinet_gl-ar300m-lite",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-glinet_gl-ar300m-lite-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "GL.iNet GL-AR300M NAND": {
+      "id": "glinet_gl-ar300m-nand",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-glinet_gl-ar300m-nand-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-nand-glinet_gl-ar300m-nand-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "GL.iNet GL-AR300M NOR": {
+      "id": "glinet_gl-ar300m-nor",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-glinet_gl-ar300m-nor-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "GL.iNet GL-AR300M16": {
+      "id": "glinet_gl-ar300m16",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-glinet_gl-ar300m16-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "GL.iNet GL-AR750": {
+      "id": "glinet_gl-ar750",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-glinet_gl-ar750-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "GL.iNet GL-AR750S NOR": {
+      "id": "glinet_gl-ar750s-nor",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-glinet_gl-ar750s-nor-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "GL.iNet GL-AR750S NOR/NAND": {
+      "id": "glinet_gl-ar750s-nor-nand",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-glinet_gl-ar750s-nor-nand-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-nand-glinet_gl-ar750s-nor-nand-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "GL.iNet GL-B1300": {
+      "id": "glinet_gl-b1300",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-glinet_gl-b1300-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "GL.iNet GL-MT300A": {
+      "id": "glinet_gl-mt300a",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-glinet_gl-mt300a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "GL.iNet GL-MT300N": {
+      "id": "glinet_gl-mt300n",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-glinet_gl-mt300n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "GL.iNet GL-MT300N V2": {
+      "id": "glinet_gl-mt300n-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-glinet_gl-mt300n-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "GL.iNet GL-MT750": {
+      "id": "glinet_gl-mt750",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-glinet_gl-mt750-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "GL.iNet GL-X750": {
+      "id": "glinet_gl-x750",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-glinet_gl-x750-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "GL.iNet VIXMINI": {
+      "id": "glinet_vixmini",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-glinet_vixmini-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Gateworks Ventana family large NAND flash": {
+      "id": "ventana",
+      "images": [
+        {
+          "name": "openwrt-imx6-ventana-large-squashfs-nand.ubi"
+        }
+      ],
+      "target": "imx6/"
+    },
+    "Gateworks Ventana family normal NAND flash": {
+      "id": "ventana",
+      "images": [
+        {
+          "name": "openwrt-imx6-ventana-squashfs-nand.ubi"
+        },
+        {
+          "name": "openwrt-imx6-ventana-squashfs-bootfs.tar.gz"
+        }
+      ],
+      "target": "imx6/"
+    },
+    "Generic 963281TAN": {
+      "id": "963281TAN-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-963281TAN-generic-squashfs-cfe-4M.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-963281TAN-generic-squashfs-cfe-8M.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-963281TAN-generic-squashfs-cfe-16M.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96328avng": {
+      "id": "96328avng-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96328avng-generic-squashfs-cfe-4M.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-96328avng-generic-squashfs-cfe-8M.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-96328avng-generic-squashfs-cfe-16M.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96338GW": {
+      "id": "96338GW-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96338GW-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96338W": {
+      "id": "96338W-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96338W-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96348GW": {
+      "id": "96348GW-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96348GW-generic-squashfs-cfe.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-96348GW-generic-squashfs-cfe-bc221.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96348GW-10": {
+      "id": "96348GW-10-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96348GW-10-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96348GW-11": {
+      "id": "96348GW-11-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96348GW-11-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96348R": {
+      "id": "96348R-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96348R-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96358VW": {
+      "id": "96358VW-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96358VW-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96358VW2": {
+      "id": "96358VW2-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96358VW2-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96368MVNgr": {
+      "id": "96368MVNgr-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96368MVNgr-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Generic 96368MVWG": {
+      "id": "96368MVWG-generic",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-96368MVWG-generic-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Globalscale Mirabox": {
+      "id": "globalscale_mirabox",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-globalscale_mirabox-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "GnuBee Personal Cloud One": {
+      "id": "gnubee_gb-pc1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-gnubee_gb-pc1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "GnuBee Personal Cloud Two": {
+      "id": "gnubee_gb-pc2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-gnubee_gb-pc2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "HAME MPR A1": {
+      "id": "hame_mpr-a1",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-hame_mpr-a1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "HAME MPR A2": {
+      "id": "hame_mpr-a2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-hame_mpr-a2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "HAOYU Electronics MarsBoard A10": {
+      "id": "marsboard_a10-marsboard",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa8-marsboard_a10-marsboard-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa8-marsboard_a10-marsboard-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa8"
+    },
+    "HILINK HLK-7628N": {
+      "id": "hilink_hlk-7628n",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-hilink_hlk-7628n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "HNET C108": {
+      "id": "hnet_c108",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-hnet_c108-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Hauppauge Broadway": {
+      "id": "hauppauge_broadway",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-hauppauge_broadway-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Head Weblink HDRM2000": {
+      "id": "head-weblink_hdrm200",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-head-weblink_hdrm200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Hi-Link HLK-RM04": {
+      "id": "hilink_hlk-rm04",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-hilink_hlk-rm04-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-hilink_hlk-rm04-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "HiWiFi HC5661": {
+      "id": "hiwifi_hc5661",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-hiwifi_hc5661-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "HiWiFi HC5661A": {
+      "id": "hiwifi_hc5661a",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-hiwifi_hc5661a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "HiWiFi HC5761": {
+      "id": "hiwifi_hc5761",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-hiwifi_hc5761-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "HiWiFi HC5761A": {
+      "id": "hiwifi_hc5761a",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-hiwifi_hc5761a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "HiWiFi HC5861": {
+      "id": "hiwifi_hc5861",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-hiwifi_hc5861-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "HiWiFi HC5861B": {
+      "id": "hiwifi_hc5861b",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-hiwifi_hc5861b-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "HooToo HT-TM02": {
+      "id": "hootoo_ht-tm02",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-hootoo_ht-tm02-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "HuaWei HG255D": {
+      "id": "huawei_hg255d",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-huawei_hg255d-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Huawei D105": {
+      "id": "huawei_d105",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-huawei_d105-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Huawei E970": {
+      "id": "huawei-e970",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-huawei-e970-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Huawei EchoLife HG520v": {
+      "id": "HG520v",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-HG520v-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Huawei EchoLife HG553": {
+      "id": "HG553",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-HG553-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Huawei EchoLife HG556a A": {
+      "id": "HG556a-A",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-HG556a-A-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Huawei EchoLife HG556a B": {
+      "id": "HG556a-B",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-HG556a-B-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Huawei EchoLife HG556a C": {
+      "id": "HG556a-C",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-HG556a-C-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Huawei EchoLife HG622": {
+      "id": "HG622",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-HG622-squashfs-cfe.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-HG622-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Huawei EchoLife HG655b": {
+      "id": "HG655b",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-HG655b-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "I-O DATA ETG3-R": {
+      "id": "iodata_etg3-r",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-iodata_etg3-r-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "I-O DATA WN-AC1167DGR": {
+      "id": "iodata_wn-ac1167dgr",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-iodata_wn-ac1167dgr-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-iodata_wn-ac1167dgr-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "I-O DATA WN-AC1167GR": {
+      "id": "iodata_wn-ac1167gr",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-iodata_wn-ac1167gr-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-iodata_wn-ac1167gr-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "I-O DATA WN-AC1600DGR": {
+      "id": "iodata_wn-ac1600dgr",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-iodata_wn-ac1600dgr-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "I-O DATA WN-AC1600DGR2/DGR3": {
+      "id": "iodata_wn-ac1600dgr2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-iodata_wn-ac1600dgr2-squashfs-dgr2-dgr3-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "I-O DATA WN-AC733GR3": {
+      "id": "iodata_wn-ac733gr3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-iodata_wn-ac733gr3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-iodata_wn-ac733gr3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "I-O DATA WN-AG300DGR": {
+      "id": "iodata_wn-ag300dgr",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-iodata_wn-ag300dgr-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-iodata_wn-ag300dgr-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "I-O DATA WN-AX1167GR": {
+      "id": "iodata_wn-ax1167gr",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-iodata_wn-ax1167gr-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "I-O DATA WN-GX300GR": {
+      "id": "iodata_wn-gx300gr",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-iodata_wn-gx300gr-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "I-O DATA WNPR2600G": {
+      "id": "iodata_wnpr2600g",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-iodata_wnpr2600g-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ITian Square One SQ201": {
+      "id": "itian_sq201",
+      "images": [
+        {
+          "name": "openwrt-gemini-itian_sq201-squashfs-factory.bin"
+        }
+      ],
+      "target": "gemini/"
+    },
+    "Image with LZMA compressed kernel matching CFE decompressor": {
+      "id": "standard-noloader-nodictionarylzma",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-standard-noloader-nodictionarylzma-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Image with LZMA loader and LZMA compressed kernel": {
+      "id": "standard",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-standard-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Image with gzipped kernel": {
+      "id": "standard-noloader-gz",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-standard-noloader-gz-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Imagination Technologies Creator Ci40 (VL-62899)": {
+      "id": "marduk",
+      "images": [
+        {
+          "name": "openwrt-pistachio-marduk-squashfs-sysupgrade.tar"
+        },
+        {
+          "name": "openwrt-pistachio-marduk-squashfs-factory.ubi"
+        }
+      ],
+      "target": "pistachio/"
+    },
+    "Imagination Technologies Marduk board": {
+      "id": "marduk",
+      "images": [
+        {
+          "name": "openwrt-pistachio-marduk-squashfs-sysupgrade.tar"
+        },
+        {
+          "name": "openwrt-pistachio-marduk-squashfs-factory.ubi"
+        }
+      ],
+      "target": "pistachio/"
+    },
+    "Intenso Memory 2 Move": {
+      "id": "intenso_memory2move",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-intenso_memory2move-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
     },
     "Iomega Iconnect": {
       "id": "iom_iconnect-1.1",
-      "target": "kirkwood",
       "images": [
-        "openwrt-kirkwood-iom_iconnect-1.1-squashfs-factory.bin",
-        "openwrt-kirkwood-iom_iconnect-1.1-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-kirkwood-iom_iconnect-1.1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-iom_iconnect-1.1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
     },
-    "ZyXEL NSA325 v1/v2": {
-      "id": "zyxel_nsa325",
-      "target": "kirkwood",
+    "Iomega StorCenter ix2-200": {
+      "id": "iom_ix2_200",
       "images": [
-        "openwrt-kirkwood-zyxel_nsa325-squashfs-factory.bin",
-        "openwrt-kirkwood-zyxel_nsa325-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-kirkwood-iom_ix2_200-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-iom_ix2_200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
+    },
+    "JCG JHR-AC876M": {
+      "id": "jcg_jhr-ac876m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-jcg_jhr-ac876m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-jcg_jhr-ac876m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "JCG JHR-N805R": {
+      "id": "jcg_jhr-n805r",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-jcg_jhr-n805r-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-jcg_jhr-n805r-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "JCG JHR-N825R": {
+      "id": "jcg_jhr-n825r",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-jcg_jhr-n825r-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-jcg_jhr-n825r-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "JCG JHR-N926R": {
+      "id": "jcg_jhr-n926r",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-jcg_jhr-n926r-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-jcg_jhr-n926r-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "KPN Experiabox 8 BRN": {
+      "id": "arcadyan_vgv7519-brn",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vgv7519-brn-squashfs-factory.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "KPN Experiabox 8 NOR": {
+      "id": "arcadyan_vgv7519-nor",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vgv7519-nor-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Kimax U25AWF H1": {
+      "id": "kimax_u25awf-h1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-kimax_u25awf-h1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Kimax U35WF": {
+      "id": "kimax_u35wf",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-kimax_u35wf-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Kingston MLW221": {
+      "id": "kingston_mlw221",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-kingston_mlw221-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Kingston MLWG2": {
+      "id": "kingston_mlwg2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-kingston_mlwg2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "LAVA LR-25G001": {
+      "id": "lava_lr-25g001",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-lava_lr-25g001-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-lava_lr-25g001-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Laird WB45N": {
+      "id": "wb45n",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-wb45n-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-wb45n-squashfs-root.ubi"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "Lamobo Lamobo R1": {
+      "id": "lamobo_lamobo-r1",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-lamobo_lamobo-r1-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-lamobo_lamobo-r1-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Lantiq Danube (EASY50712)": {
+      "id": "lantiq_easy50712",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-lantiq_easy50712-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Lantiq EASY88388 Falcon FTTDP8 Reference Board": {
+      "id": "lantiq_easy88388",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy88388-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq EASY88444 Falcon FTTdp G.FAST Reference Board": {
+      "id": "lantiq_easy88444",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy88444-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq EASY98000 Falcon Eval Board NAND": {
+      "id": "lantiq_easy98000-nand",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy98000-nand-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq EASY98000 Falcon Eval Board NOR": {
+      "id": "lantiq_easy98000-nor",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy98000-nor-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq EASY98000 Falcon Eval Board SFLASH": {
+      "id": "lantiq_easy98000-sflash",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy98000-sflash-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq Falcon / VINAXdp MDU Board": {
+      "id": "lantiq_falcon-mdu",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_falcon-mdu-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq Falcon HGU Reference Board (EASY98021)": {
+      "id": "lantiq_easy98021",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy98021-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq Falcon SFP Stick": {
+      "id": "lantiq_falcon-sfp",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_falcon-sfp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq Falcon SFP Stick (EASY98035SYNCE) with Synchronous Ethernet": {
+      "id": "lantiq_easy98035synce",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy98035synce-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq Falcon SFP Stick (EASY98035SYNCE1588) with SyncE and IEEE1588": {
+      "id": "lantiq_easy98035synce1588",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy98035synce1588-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq Falcon SFU Reference Board (EASY98020) v1.0-v1.7": {
+      "id": "lantiq_easy98020",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy98020-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq Falcon SFU Reference Board (EASY98020) v1.8": {
+      "id": "lantiq_easy98020-v18",
+      "images": [
+        {
+          "name": "openwrt-lantiq-falcon-lantiq_easy98020-v18-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/falcon"
+    },
+    "Lantiq VR9 EASY80920 NAND": {
+      "id": "lantiq_easy80920-nand",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-lantiq_easy80920-nand-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xrx200-lantiq_easy80920-nand-squashfs-fullimage.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "Lantiq VR9 EASY80920 NOR": {
+      "id": "lantiq_easy80920-nor",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-lantiq_easy80920-nor-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "LeMaker Banana Pi": {
+      "id": "lemaker_bananapi",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-lemaker_bananapi-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-lemaker_bananapi-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "LeMaker Banana Pi M2 Ultra": {
+      "id": "lemaker_bananapi-m2-ultra",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-lemaker_bananapi-m2-ultra-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-lemaker_bananapi-m2-ultra-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "LeMaker Banana Pi R2": {
+      "id": "lemaker_bananapi-bpi-r2",
+      "images": [
+        {
+          "name": "openwrt-mediatek-mt7623-lemaker_bananapi-bpi-r2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mediatek/mt7623"
+    },
+    "LeMaker Banana Pi R64": {
+      "id": "lemaker_bananapi-bpi-r64",
+      "images": [
+        {
+          "name": "openwrt-mediatek-mt7622-lemaker_bananapi-bpi-r64-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mediatek/mt7622"
+    },
+    "LeMaker Banana Pro": {
+      "id": "lemaker_bananapro",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-lemaker_bananapro-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-lemaker_bananapro-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Lenovo Y1": {
+      "id": "lenovo_newifi-y1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-lenovo_newifi-y1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Lenovo Y1S": {
+      "id": "lenovo_newifi-y1s",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-lenovo_newifi-y1s-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Librerouter LibreRouter v1": {
+      "id": "librerouter_librerouter-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-librerouter_librerouter-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "LinkSprite pcDuino": {
+      "id": "linksprite_a10-pcduino",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa8-linksprite_a10-pcduino-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa8-linksprite_a10-pcduino-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa8"
+    },
+    "LinkSprite pcDuino3": {
+      "id": "linksprite_pcduino3",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-linksprite_pcduino3-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-linksprite_pcduino3-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Linksys Caiman": {
+      "id": "linksys_wrt1200ac",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1200ac-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1200ac-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys Cobra": {
+      "id": "linksys_wrt1900acv2",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acv2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acv2-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys E1000 v1/v2/v2.1": {
+      "id": "linksys-e1000",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e1000-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E1200 v1": {
+      "id": "linksys-e1200-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e1200-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E1200 v2": {
+      "id": "linksys-e1200-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e1200-v2-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E1500 v1": {
+      "id": "linksys-e1500-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e1500-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E1550 v1": {
+      "id": "linksys-e1550-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e1550-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E1700": {
+      "id": "linksys_e1700",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-linksys_e1700-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-linksys_e1700-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Linksys E2000 v1": {
+      "id": "linksys-e2000-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e2000-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E2500 v1": {
+      "id": "linksys-e2500-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e2500-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E2500 v2": {
+      "id": "linksys-e2500-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e2500-v2-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E2500 v2.1": {
+      "id": "linksys-e2500-v2.1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e2500-v2.1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E2500 v3": {
+      "id": "linksys-e2500-v3",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e2500-v3-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E3000 v1": {
+      "id": "linksys-e3000-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-generic-linksys-e3000-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/generic"
+    },
+    "Linksys E3200 v1": {
+      "id": "linksys-e3200-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e3200-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E4200 v1": {
+      "id": "linksys-e4200-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e4200-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys E4200v2 / EA4500 (Viper)": {
+      "id": "linksys_viper",
+      "images": [
+        {
+          "name": "openwrt-kirkwood-linksys_viper-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-linksys_viper-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
+    },
+    "Linksys E900 v1": {
+      "id": "linksys-e900-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-e900-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys EA3500 (Audi)": {
+      "id": "linksys_audi",
+      "images": [
+        {
+          "name": "openwrt-kirkwood-linksys_audi-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-linksys_audi-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
+    },
+    "Linksys EA6350 v3": {
+      "id": "linksys_ea6350v3",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-linksys_ea6350v3-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-linksys_ea6350v3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Linksys EA6500 v2": {
+      "id": "linksys-ea6500-v2",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-linksys-ea6500-v2-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "Linksys EA8300": {
+      "id": "linksys_ea8300",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-linksys_ea8300-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-linksys_ea8300-squashfs-factory.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Linksys EA8500": {
+      "id": "linksys_ea8500",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-linksys_ea8500-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-linksys_ea8500-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "Linksys Mamba": {
+      "id": "linksys_wrt1900ac",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900ac-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900ac-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys RE6500": {
+      "id": "linksys_re6500",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-linksys_re6500-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Linksys Rango": {
+      "id": "linksys_wrt3200acm",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt3200acm-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt3200acm-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys Shelby": {
+      "id": "linksys_wrt1900acs",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys Venom": {
+      "id": "linksys_wrt32x",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt32x-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt32x-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys WRT1200AC": {
+      "id": "linksys_wrt1200ac",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1200ac-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1200ac-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys WRT150N": {
+      "id": "linksys-wrt150n",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt150n-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT160N v1": {
+      "id": "linksys-wrt160n-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt160n-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT160N v3": {
+      "id": "linksys-wrt160n-v3",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-wrt160n-v3-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys WRT1900AC v1": {
+      "id": "linksys_wrt1900ac",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900ac-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900ac-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys WRT1900AC v2": {
+      "id": "linksys_wrt1900acv2",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acv2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acv2-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys WRT1900ACS v1": {
+      "id": "linksys_wrt1900acs",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys WRT1900ACS v2": {
+      "id": "linksys_wrt1900acs",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt1900acs-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys WRT300N v1": {
+      "id": "linksys-wrt300n-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt300n-v1-squashfs.bin"
+        },
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt300n-v1-squashfs.trx"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT300N v1.1": {
+      "id": "linksys-wrt300n-v1.1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-generic-linksys-wrt300n-v1.1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/generic"
+    },
+    "Linksys WRT310N v1": {
+      "id": "linksys-wrt310n-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-generic-linksys-wrt310n-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/generic"
+    },
+    "Linksys WRT310N v2": {
+      "id": "linksys-wrt310n-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-wrt310n-v2-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys WRT3200ACM": {
+      "id": "linksys_wrt3200acm",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt3200acm-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt3200acm-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys WRT320N v1": {
+      "id": "linksys-wrt320n-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-linksys-wrt320n-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "Linksys WRT32X": {
+      "id": "linksys_wrt32x",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt32x-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-linksys_wrt32x-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Linksys WRT350N v1": {
+      "id": "linksys-wrt350n-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-generic-linksys-wrt350n-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/generic"
+    },
+    "Linksys WRT54G": {
+      "id": "linksys-wrt54g",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt54g-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT54G-TM v1": {
+      "id": "linksys-wrt54gs",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt54gs-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT54G3G": {
+      "id": "linksys-wrt54g3g",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt54g3g-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT54G3G-EM": {
+      "id": "linksys-wrt54g3g-em",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt54g3g-em-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT54G3GV2-VF": {
+      "id": "linksys-wrt54g3gv2-vf",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt54g3gv2-vf-squashfs.noheader.bin"
+        },
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt54g3gv2-vf-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT54GS v1/v2/v3": {
+      "id": "linksys-wrt54gs",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt54gs-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT54GS v4": {
+      "id": "linksys-wrt54gs-v4",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrt54gs-v4-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Linksys WRT610N v1": {
+      "id": "linksys-wrt610n-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-generic-linksys-wrt610n-v1-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/generic"
+    },
+    "Linksys WRT610N v2": {
+      "id": "linksys-wrt610n-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-generic-linksys-wrt610n-v2-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/generic"
+    },
+    "Linksys WRTSL54GS": {
+      "id": "linksys-wrtsl54gs",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-linksys-wrtsl54gs-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Loewe WMDR-143N": {
+      "id": "loewe_wmdr-143n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-loewe_wmdr-143n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "MQmaker WiTi": {
+      "id": "mqmaker_witi",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-mqmaker_witi-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "MTC Wireless Router WR1201": {
+      "id": "mtc_wr1201",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-mtc_wr1201-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Marvell Armada 370 Development Board (DB-88F6710-BP-DDR3)": {
+      "id": "marvell_a370-db",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-marvell_a370-db-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Marvell Armada 370 RD (RD-88F6710-A1)": {
+      "id": "marvell_a370-rd",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-marvell_a370-rd-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Marvell Armada 3700 Community Board Non-eMMC": {
+      "id": "globalscale_espressobin",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Marvell Armada 3700 Community Board V7 Non-eMMC": {
+      "id": "globalscale_espressobin-v7",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Marvell Armada 3700 Community Board V7 eMMC": {
+      "id": "globalscale_espressobin-v7-emmc",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-emmc-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-emmc-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Marvell Armada 3700 Community Board eMMC": {
+      "id": "globalscale_espressobin-emmc",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-emmc-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-emmc-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Marvell Armada 3720 Development Board (DB-88F3720-DDR3)": {
+      "id": "marvell_armada-3720-db",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-marvell_armada-3720-db-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-marvell_armada-3720-db-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Marvell Armada 385 Development Board AP (DB-88F6820-AP)": {
+      "id": "marvell_a385-db-ap",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-marvell_a385-db-ap-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-marvell_a385-db-ap-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Marvell Armada 388 RD (RD-88F6820-AP)": {
+      "id": "marvell_a388-rd",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-marvell_a388-rd-squashfs-firmware.bin"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Marvell Armada 7040 Development Board": {
+      "id": "marvell_armada7040-db",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa72-marvell_armada7040-db-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa72-marvell_armada7040-db-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa72"
+    },
+    "Marvell Armada 8040 Development Board": {
+      "id": "marvell_armada8040-db",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa72-marvell_armada8040-db-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa72-marvell_armada8040-db-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa72"
+    },
+    "Marvell Armada Armada XP GP (DB-MV784MP-GP)": {
+      "id": "marvell_axp-gp",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-marvell_axp-gp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Marvell Armada XP Development Board (DB-78460-BP)": {
+      "id": "marvell_axp-db",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-marvell_axp-db-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Marvell ESPRESSObin Non-eMMC": {
+      "id": "globalscale_espressobin",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Marvell ESPRESSObin V7 Non-eMMC": {
+      "id": "globalscale_espressobin-v7",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Marvell ESPRESSObin V7 eMMC": {
+      "id": "globalscale_espressobin-v7-emmc",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-emmc-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-v7-emmc-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Marvell ESPRESSObin eMMC": {
+      "id": "globalscale_espressobin-emmc",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-emmc-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa53-globalscale_espressobin-emmc-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "MediaTek LinkIt Smart 7688": {
+      "id": "mediatek_linkit-smart-7688",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-mediatek_linkit-smart-7688-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "MediaTek MT7620a + MT7530 EVB": {
+      "id": "ralink_mt7620a-mt7530-evb",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-ralink_mt7620a-mt7530-evb-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "MediaTek MT7620a + MT7610e EVB": {
+      "id": "ralink_mt7620a-mt7610e-evb",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-ralink_mt7620a-mt7610e-evb-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "MediaTek MT7620a EVB": {
+      "id": "ralink_mt7620a-evb",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-ralink_mt7620a-evb-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "MediaTek MT7620a V22SG": {
+      "id": "ralink_mt7620a-v22sg-evb",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-ralink_mt7620a-v22sg-evb-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "MediaTek MT7621 EVB": {
+      "id": "mediatek_mt7621-eval-board",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-mediatek_mt7621-eval-board-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "MediaTek MT7628 EVB": {
+      "id": "mediatek_mt7628an-eval-board",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-mediatek_mt7628an-eval-board-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "MediaTek MT7629 Lynx reference board": {
+      "id": "mediatek_mt7629-lynx-rfb",
+      "images": [
+        {
+          "name": "openwrt-mediatek-mt7629-mediatek_mt7629-lynx-rfb-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mediatek/mt7629"
+    },
+    "MediaTek MTK7622 Lynx rfb1 AP": {
+      "id": "mediatek_mt7622-lynx-rfb1",
+      "images": [
+        {
+          "name": "openwrt-mediatek-mt7622-mediatek_mt7622-lynx-rfb1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mediatek/mt7622"
+    },
+    "MediaTek MTK7622 rfb1 AP": {
+      "id": "mediatek_mt7622-rfb1",
+      "images": [
+        {
+          "name": "openwrt-mediatek-mt7622-mediatek_mt7622-rfb1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mediatek/mt7622"
+    },
+    "Mediatek AP-MT7621A-V60 EVB": {
+      "id": "mediatek_ap-mt7621a-v60",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-mediatek_ap-mt7621a-v60-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Mele M9": {
+      "id": "mele_m9",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-mele_m9-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-mele_m9-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Mercury MAC1200R v2.0": {
+      "id": "mercury_mac1200r-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-mercury_mac1200r-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Methode micro-DPU (uDPU)": {
+      "id": "methode_udpu",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa53-methode_udpu-firmware.tgz"
+        }
+      ],
+      "target": "mvebu/cortexa53"
+    },
+    "Microchip SAMA5D2 PTC Ek": {
+      "id": "at91-sama5d2_ptc_ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_ptc_ek-ubifs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_ptc_ek-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_ptc_ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_ptc_ek-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "at91/sama5"
+    },
+    "Microchip SAMA5D2 Xplained": {
+      "id": "at91-sama5d2_xplained",
+      "images": [
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_xplained-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_xplained-ubifs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_xplained-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_xplained-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d2_xplained-squashfs-zImage"
+        }
+      ],
+      "target": "at91/sama5"
+    },
+    "Microchip SAMA5D27 SOM1 Ek": {
+      "id": "at91-sama5d27_som1_ek",
+      "images": [
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d27_som1_ek-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d27_som1_ek-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d27_som1_ek-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d27_som1_ek-squashfs-zImage"
+        }
+      ],
+      "target": "at91/sama5"
+    },
+    "Microchip SAMA5D3 Xplained": {
+      "id": "at91-sama5d3_xplained",
+      "images": [
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d3_xplained-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d3_xplained-ubifs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d3_xplained-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d3_xplained-squashfs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d3_xplained-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "at91/sama5"
+    },
+    "Microchip SAMA5D4 Xplained": {
+      "id": "at91-sama5d4_xplained",
+      "images": [
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d4_xplained-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d4_xplained-ubifs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d4_xplained-squashfs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d4_xplained-squashfs-zImage"
+        },
+        {
+          "name": "openwrt-at91-sama5-at91-sama5d4_xplained-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "at91/sama5"
+    },
+    "Microduino MicroWRT": {
+      "id": "microduino_microwrt",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-microduino_microwrt-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "MikroTik RouterBOARD 532": {
+      "id": "nand",
+      "images": [
+        {
+          "name": "openwrt-rb532-nand-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "rb532/"
+    },
+    "MikroTik RouterBOARD M11G": {
+      "id": "mikrotik_rbm11g",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-mikrotik_rbm11g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "MikroTik RouterBOARD M33G": {
+      "id": "mikrotik_rbm33g",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-mikrotik_rbm33g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "MikroTik RouterBOARD RB750G r3": {
+      "id": "mikrotik_rb750gr3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-mikrotik_rb750gr3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "MikroTik RouterBOARD wAP G-5HacT2HnD (wAP AC)": {
+      "id": "mikrotik_routerboard-wap-g-5hact2hnd",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-mikrotik_routerboard-wap-g-5hact2hnd-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "MitraStar STG-212": {
+      "id": "mitrastar_stg-212",
+      "images": [
+        {
+          "name": "openwrt-oxnas-ox820-mitrastar_stg-212-ubifs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-mitrastar_stg-212-ubifs-sysupgrade.tar"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-mitrastar_stg-212-squashfs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-mitrastar_stg-212-squashfs-sysupgrade.tar"
+        }
+      ],
+      "target": "oxnas/ox820"
+    },
+    "MoFi Network MOFI3500-3GN": {
+      "id": "mofinetwork_mofi3500-3gn",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-mofinetwork_mofi3500-3gn-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Motorola WA840G": {
+      "id": "motorola-wa840g",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-motorola-wa840g-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Motorola WE800G": {
+      "id": "motorola-we800g",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-motorola-we800g-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Motorola WR850G": {
+      "id": "motorola-wr850g",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-motorola-wr850g-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "NEC Aterm WG1200CR": {
+      "id": "nec_wg1200cr",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-nec_wg1200cr-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-nec_wg1200cr-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NEC Aterm WG2600HP": {
+      "id": "nec_wg2600hp",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-nec_wg2600hp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "NEC Aterm WG800HP": {
+      "id": "nec_wg800hp",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-nec_wg800hp-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-nec_wg800hp-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR Centria N900 WNDR4700/WNDR4720": {
+      "id": "netgear_wndr4700",
+      "images": [
+        {
+          "name": "openwrt-apm821xx-nand-netgear_wndr4700-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-apm821xx-nand-netgear_wndr4700-squashfs-factory.img"
+        }
+      ],
+      "target": "apm821xx/nand"
+    },
+    "NETGEAR DGN1000B": {
+      "id": "netgear_dgn1000b",
+      "images": [
+        {
+          "name": "openwrt-lantiq-ase-netgear_dgn1000b-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/ase"
+    },
+    "NETGEAR DGN3500": {
+      "id": "netgear_dgn3500",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-netgear_dgn3500-squashfs-sysupgrade-na.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xway-netgear_dgn3500-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xway-netgear_dgn3500-squashfs-factory-na.img"
+        },
+        {
+          "name": "openwrt-lantiq-xway-netgear_dgn3500-squashfs-factory.img"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "NETGEAR DGN3500B": {
+      "id": "netgear_dgn3500b",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-netgear_dgn3500b-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xway-netgear_dgn3500b-squashfs-factory.img"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "NETGEAR DGND3700 v1": {
+      "id": "DGND3700v1",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DGND3700v1-squashfs-factory.chk"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-DGND3700v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "NETGEAR DGND3800B": {
+      "id": "DGND3800B",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-DGND3800B-squashfs-factory.chk"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-DGND3800B-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "NETGEAR DM200": {
+      "id": "netgear_dm200",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-netgear_dm200-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-lantiq-xrx200-netgear_dm200-squashfs-factory.img"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "NETGEAR EVG2000": {
+      "id": "EVG2000",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-EVG2000-squashfs-factory.chk"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-EVG2000-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "NETGEAR EX2700": {
+      "id": "netgear_ex2700",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-netgear_ex2700-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-netgear_ex2700-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "NETGEAR EX3700/EX3800": {
+      "id": "netgear_ex3700",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-netgear_ex3700-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-netgear_ex3700-squashfs-factory.chk"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "NETGEAR EX6130": {
+      "id": "netgear_ex6130",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-netgear_ex6130-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-netgear_ex6130-squashfs-factory.chk"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "NETGEAR EX6150": {
+      "id": "netgear_ex6150",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-netgear_ex6150-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_ex6150-squashfs-factory.chk"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "NETGEAR EX6400": {
+      "id": "netgear_ex6400",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_ex6400-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_ex6400-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR EX7300": {
+      "id": "netgear_ex7300",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_ex7300-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_ex7300-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR Nighthawk X4 D7800": {
+      "id": "netgear_d7800",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-netgear_d7800-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-netgear_d7800-squashfs-factory.img"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "NETGEAR Nighthawk X4 R7500 v1": {
+      "id": "netgear_r7500",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-netgear_r7500-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-netgear_r7500-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "NETGEAR Nighthawk X4 R7500 v2": {
+      "id": "netgear_r7500v2",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-netgear_r7500v2-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-netgear_r7500v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "NETGEAR Nighthawk X4S R7800": {
+      "id": "netgear_r7800",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-netgear_r7800-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-netgear_r7800-squashfs-factory.img"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "NETGEAR R6120": {
+      "id": "netgear_r6120",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-netgear_r6120-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-netgear_r6120-squashfs-factory.img"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "NETGEAR R6220": {
+      "id": "netgear_r6220",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6220-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6220-squashfs-kernel.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6220-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6220-squashfs-rootfs.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "NETGEAR R6250": {
+      "id": "netgear-r6250",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-netgear-r6250-squashfs.chk"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "NETGEAR R6260": {
+      "id": "netgear_r6260",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6260-squashfs-kernel.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6260-squashfs-factory.img"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "NETGEAR R6300 v2": {
+      "id": "netgear-r6300-v2",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-netgear-r6300-v2-squashfs.chk"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "NETGEAR R6350": {
+      "id": "netgear_r6350",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6350-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6350-squashfs-kernel.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6350-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6350-squashfs-rootfs.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "NETGEAR R6850": {
+      "id": "netgear_r6850",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6850-squashfs-kernel.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6850-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6850-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_r6850-squashfs-rootfs.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "NETGEAR R7000": {
+      "id": "netgear-r7000",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-netgear-r7000-squashfs.chk"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "NETGEAR R7900": {
+      "id": "netgear-r7900",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-netgear-r7900-squashfs.chk"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "NETGEAR R8000": {
+      "id": "netgear-r8000",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-netgear-r8000-squashfs.chk"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "NETGEAR WGR614 v10": {
+      "id": "netgear-wgr614-v10",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wgr614-v10-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WGR614 v10 (NA)": {
+      "id": "netgear-wgr614-v10-na",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wgr614-v10-na-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WGR614 v8": {
+      "id": "netgear-wgr614-v8",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-netgear-wgr614-v8-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "NETGEAR WGT634U": {
+      "id": "netgear-wgt634u",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-netgear-wgt634u-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "NETGEAR WN2500RP v1": {
+      "id": "netgear-wn2500rp-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wn2500rp-v1-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WN3000RP": {
+      "id": "netgear-wn3000rp",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wn3000rp-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WN3000RP v3": {
+      "id": "netgear_wn3000rp-v3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-netgear_wn3000rp-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-netgear_wn3000rp-v3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "NETGEAR WNCE2001": {
+      "id": "netgear_wnce2001",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-netgear_wnce2001-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-netgear_wnce2001-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-netgear_wnce2001-squashfs-factory-NA.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "NETGEAR WNDAP620 (Premium Wireless-N)": {
+      "id": "netgear_wndap620",
+      "images": [
+        {
+          "name": "openwrt-apm821xx-nand-netgear_wndap620-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-apm821xx-nand-netgear_wndap620-squashfs-factory.img"
+        }
+      ],
+      "target": "apm821xx/nand"
+    },
+    "NETGEAR WNDAP660 (Dual Radio Dual Band Wireless-N)": {
+      "id": "netgear_wndap660",
+      "images": [
+        {
+          "name": "openwrt-apm821xx-nand-netgear_wndap660-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-apm821xx-nand-netgear_wndap660-squashfs-factory.img"
+        }
+      ],
+      "target": "apm821xx/nand"
+    },
+    "NETGEAR WNDR3300 v1": {
+      "id": "netgear-wndr3300-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-netgear-wndr3300-v1-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "NETGEAR WNDR3400 v1": {
+      "id": "netgear-wndr3400-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wndr3400-v1-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNDR3400 v2": {
+      "id": "netgear-wndr3400-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wndr3400-v2-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNDR3400 v3": {
+      "id": "netgear-wndr3400-v3",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wndr3400-v3-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNDR3700 v1": {
+      "id": "netgear_wndr3700",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3700-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3700-squashfs-factory-NA.img"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3700-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR WNDR3700 v2": {
+      "id": "netgear_wndr3700v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3700v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3700v2-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR WNDR3700 v3": {
+      "id": "netgear-wndr3700-v3",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wndr3700-v3-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNDR3700 v4": {
+      "id": "netgear_wndr3700-v4",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-netgear_wndr3700-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-nand-netgear_wndr3700-v4-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "NETGEAR WNDR3700 v5": {
+      "id": "netgear_wndr3700-v5",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-netgear_wndr3700-v5-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-netgear_wndr3700-v5-squashfs-factory.img"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "NETGEAR WNDR3800": {
+      "id": "netgear_wndr3800",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3800-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3800-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR WNDR3800CH": {
+      "id": "netgear_wndr3800ch",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3800ch-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wndr3800ch-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR WNDR4000 v1": {
+      "id": "netgear-wndr4000",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wndr4000-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNDR4300": {
+      "id": "netgear_wndr4300",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-netgear_wndr4300-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-nand-netgear_wndr4300-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "NETGEAR WNDR4300 v2": {
+      "id": "netgear_wndr4300-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-netgear_wndr4300-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-nand-netgear_wndr4300-v2-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "NETGEAR WNDR4500 v3": {
+      "id": "netgear_wndr4500-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-netgear_wndr4500-v3-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-nand-netgear_wndr4500-v3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "NETGEAR WNR1000 v2": {
+      "id": "netgear_wnr1000-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-netgear_wnr1000-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-netgear_wnr1000-v2-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "NETGEAR WNR1000 v3": {
+      "id": "netgear-wnr1000-v3",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wnr1000-v3-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNR2000 v2": {
+      "id": "netgear-wnr2000v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wnr2000v2-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNR2000 v3": {
+      "id": "netgear_wnr2000-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-netgear_wnr2000-v3-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-tiny-netgear_wnr2000-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-netgear_wnr2000-v3-squashfs-factory-NA.img"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "NETGEAR WNR2200 16M": {
+      "id": "netgear_wnr2200-16m",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_wnr2200-16m-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wnr2200-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR WNR2200 8M": {
+      "id": "netgear_wnr2200-8m",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_wnr2200-8m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wnr2200-8m-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wnr2200-8m-squashfs-factory-NA.img"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR WNR2200 CN/RU": {
+      "id": "netgear_wnr2200-16m",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-netgear_wnr2200-16m-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-generic-netgear_wnr2200-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "NETGEAR WNR3500 v2": {
+      "id": "netgear-wnr3500-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wnr3500-v2-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNR3500L v1 (NA)": {
+      "id": "netgear-wnr3500l-v1-na",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wnr3500l-v1-na-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNR3500L v1 (ROW)": {
+      "id": "netgear-wnr3500l-v1",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wnr3500l-v1-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNR3500L v2": {
+      "id": "netgear-wnr3500l-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-mips74k-netgear-wnr3500l-v2-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/mips74k"
+    },
+    "NETGEAR WNR612 v2": {
+      "id": "netgear_wnr612-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-netgear_wnr612-v2-squashfs-factory.img"
+        },
+        {
+          "name": "openwrt-ath79-tiny-netgear_wnr612-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "NETGEAR WNR834B v2": {
+      "id": "netgear-wnr834b-v2",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-netgear-wnr834b-v2-squashfs.chk"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "NETIS WF-2881": {
+      "id": "netis_wf-2881",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-netis_wf-2881-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "NXP LS1012A-RDB": {
+      "id": "ls1012ardb",
+      "images": [
+        {
+          "name": "openwrt-layerscape-armv8_64b-ls1012ardb-ubifs-firmware.bin"
+        }
+      ],
+      "target": "layerscape/armv8_64b"
+    },
+    "NXP LS1043A-RDB Default": {
+      "id": "ls1043ardb",
+      "images": [
+        {
+          "name": "openwrt-layerscape-armv8_64b-ls1043ardb-squashfs-firmware.bin"
+        }
+      ],
+      "target": "layerscape/armv8_64b"
+    },
+    "NXP LS1046A-RDB Default": {
+      "id": "ls1046ardb",
+      "images": [
+        {
+          "name": "openwrt-layerscape-armv8_64b-ls1046ardb-ubifs-firmware.bin"
+        }
+      ],
+      "target": "layerscape/armv8_64b"
+    },
+    "NXP LS1088A-RDB Default": {
+      "id": "ls1088ardb",
+      "images": [
+        {
+          "name": "openwrt-layerscape-armv8_64b-ls1088ardb-ubifs-firmware.bin"
+        }
+      ],
+      "target": "layerscape/armv8_64b"
+    },
+    "NXP LS2088ARDB": {
+      "id": "ls2088ardb",
+      "images": [
+        {
+          "name": "openwrt-layerscape-armv8_64b-ls2088ardb-squashfs-firmware.bin"
+        }
+      ],
+      "target": "layerscape/armv8_64b"
+    },
+    "NXP TWR-LS1021A Default": {
+      "id": "ls1021atwr",
+      "images": [
+        {
+          "name": "openwrt-layerscape-armv7-ls1021atwr-squashfs-firmware.bin"
+        }
+      ],
+      "target": "layerscape/armv7"
+    },
+    "Netcore NW718": {
+      "id": "netcore_nw718",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-netcore_nw718-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Netgear EX6100 v2": {
+      "id": "netgear_ex6100v2",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-netgear_ex6100v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-netgear_ex6100v2-squashfs-factory.img"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Netgear EX6150 v2": {
+      "id": "netgear_ex6150v2",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-netgear_ex6150v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-netgear_ex6150v2-squashfs-factory.img"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Newifi D1": {
+      "id": "lenovo_newifi-d1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-lenovo_newifi-d1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Newifi D2": {
+      "id": "d-team_newifi-d2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-d-team_newifi-d2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "NexAira BC2": {
+      "id": "nexaira_bc2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-nexaira_bc2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Nexx WT1520 4M": {
+      "id": "nexx_wt1520-4m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-nexx_wt1520-4m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-nexx_wt1520-4m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Nexx WT1520 8M": {
+      "id": "nexx_wt1520-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-nexx_wt1520-8m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-nexx_wt1520-8m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Nexx WT3020 4M": {
+      "id": "nexx_wt3020-4m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-nexx_wt3020-4m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-nexx_wt3020-4m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Nexx WT3020 8M": {
+      "id": "nexx_wt3020-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-nexx_wt3020-8m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-nexx_wt3020-8m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Nixcore X1 16M": {
+      "id": "nixcore_x1-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-nixcore_x1-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Nixcore X1 8M": {
+      "id": "nixcore_x1-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-nixcore_x1-8m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "NuCom R5010UN v2": {
+      "id": "R5010UNv2",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-R5010UNv2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-R5010UNv2-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "OCEDO Panda": {
+      "id": "ocedo_panda",
+      "images": [
+        {
+          "name": "openwrt-mpc85xx-p1020-ocedo_panda-squashfs-fdt.bin"
+        },
+        {
+          "name": "openwrt-mpc85xx-p1020-ocedo_panda-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mpc85xx/p1020"
+    },
+    "OLIMEX RT5350F-OLinuXino": {
+      "id": "olimex_rt5350f-olinuxino",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-olimex_rt5350f-olinuxino-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "OLIMEX RT5350F-OLinuXino-EVB": {
+      "id": "olimex_rt5350f-olinuxino-evb",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-olimex_rt5350f-olinuxino-evb-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Observa VH4032N": {
+      "id": "VH4032N",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-VH4032N-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-VH4032N-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Ocedo Koala": {
+      "id": "ocedo_koala",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ocedo_koala-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ocedo Raccoon": {
+      "id": "ocedo_raccoon",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ocedo_raccoon-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ocedo Ursus": {
+      "id": "ocedo_ursus",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ocedo_ursus-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Oh Yeah OY-0001": {
+      "id": "ohyeah_oy-0001",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-ohyeah_oy-0001-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Olimex A10-OLinuXino-LIME": {
+      "id": "olimex_a10-olinuxino-lime",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa8-olimex_a10-olinuxino-lime-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa8-olimex_a10-olinuxino-lime-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa8"
+    },
+    "Olimex A13-OLinuXino": {
+      "id": "olimex_a13-olinuxino",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa8-olimex_a13-olinuxino-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa8-olimex_a13-olinuxino-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa8"
+    },
+    "Olimex A13-SOM": {
+      "id": "olimex_a13-olimex-som",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa8-olimex_a13-olimex-som-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa8-olimex_a13-olimex-som-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa8"
+    },
+    "Olimex A20-OLinuXino-LIME": {
+      "id": "olimex_a20-olinuxino-lime",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Olimex A20-OLinuXino-LIME2": {
+      "id": "olimex_a20-olinuxino-lime2",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime2-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime2-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Olimex A20-OLinuXino-LIME2 eMMC": {
+      "id": "olimex_a20-olinuxino-lime2-emmc",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime2-emmc-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-lime2-emmc-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Olimex A20-OLinuXino-MICRO": {
+      "id": "olimex_a20-olinuxino-micro",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-micro-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-olimex_a20-olinuxino-micro-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Omnima HPM": {
+      "id": "omnima_hpm",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-omnima_hpm-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "Omnima MiniEMBPlug": {
+      "id": "omnima_miniembplug",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-omnima_miniembplug-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Omnima MiniEMBWiFi": {
+      "id": "omnima_miniembwifi",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-omnima_miniembwifi-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "On Networks N150R": {
+      "id": "on_n150r",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-on_n150r-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-on_n150r-squashfs-factory.img"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "Onion Omega2": {
+      "id": "onion_omega2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-onion_omega2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Onion Omega2+": {
+      "id": "onion_omega2p",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-onion_omega2p-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "OpenMesh A42": {
+      "id": "openmesh_a42",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-openmesh_a42-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-openmesh_a42-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "OpenMesh A62": {
+      "id": "openmesh_a62",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-openmesh_a62-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-openmesh_a62-squashfs-factory.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "OpenMesh OM5P-AC v2": {
+      "id": "openmesh_om5p-ac-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-openmesh_om5p-ac-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Orange Livebox 2.1": {
+      "id": "arcadyan_arv7519rw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_arv7519rw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "PHICOMM K3": {
+      "id": "phicomm-k3",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-phicomm-k3-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "PISEN Cloud Easy Power (WMM003N)": {
+      "id": "pisen_wmm003n",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-pisen_wmm003n-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-pisen_wmm003n-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "PISEN TS-D084": {
+      "id": "pisen_ts-d084",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-pisen_ts-d084-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-pisen_ts-d084-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "PISEN WMB001N": {
+      "id": "pisen_wmb001n",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-pisen_wmb001n-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-pisen_wmb001n-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "PQI Air-Pen": {
+      "id": "pqi_air-pen",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-pqi_air-pen-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "PandaBoard.org OMAP4 TI pandaboard": {
+      "id": "ti_omap4-panda",
+      "images": [
+        {
+          "name": "openwrt-omap-ti_omap4-panda-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-omap-ti_omap4-panda-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "omap/"
+    },
+    "PandoraBox PBR-D1": {
+      "id": "d-team_pbr-d1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-d-team_pbr-d1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "PandoraBox PBR-M1": {
+      "id": "d-team_pbr-m1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-d-team_pbr-m1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Petatel PSR-680W Wireless 3G Router": {
+      "id": "petatel_psr-680w",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-petatel_psr-680w-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Phicomm K2G": {
+      "id": "phicomm_k2g",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-phicomm_k2g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Phicomm K2P": {
+      "id": "phicomm_k2p",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-phicomm_k2p-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Phicomm K2T": {
+      "id": "phicomm_k2t",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-phicomm_k2t-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Phicomm KE 2P": {
+      "id": "phicomm_k2p",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-phicomm_k2p-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Phicomm PSG1208": {
+      "id": "phicomm_psg1208",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-phicomm_psg1208-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Phicomm PSG1218 Ax": {
+      "id": "phicomm_psg1218a",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-phicomm_psg1218a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Phicomm PSG1218 Bx": {
+      "id": "phicomm_psg1218b",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-phicomm_psg1218b-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Pine64 Pine64+": {
+      "id": "pine64_pine64-plus",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa53-pine64_pine64-plus-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa53-pine64_pine64-plus-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa53"
+    },
+    "Pine64 SoPine": {
+      "id": "pine64_sopine-baseboard",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa53-pine64_sopine-baseboard-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa53-pine64_sopine-baseboard-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa53"
+    },
+    "Pirelli A226G": {
+      "id": "A226G",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-A226G-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Pirelli A226M": {
+      "id": "A226M",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-A226M-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Pirelli A226M-FWB": {
+      "id": "A226M-FWB",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-A226M-FWB-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Pirelli Alice Gate VoIP 2 Plus Wi-Fi AGPF-S0": {
+      "id": "AGPF-S0",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-AGPF-S0-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Planex CS-QR10": {
+      "id": "planex_cs-qr10",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-planex_cs-qr10-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Planex DB-WRT01": {
+      "id": "planex_db-wrt01",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-planex_db-wrt01-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Planex MZK-750DHP": {
+      "id": "planex_mzk-750dhp",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-planex_mzk-750dhp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Planex MZK-DP150N": {
+      "id": "planex_mzk-dp150n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-planex_mzk-dp150n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Planex MZK-EX300NP": {
+      "id": "planex_mzk-ex300np",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-planex_mzk-ex300np-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Planex MZK-EX750NP": {
+      "id": "planex_mzk-ex750np",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-planex_mzk-ex750np-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Planex MZK-W300NH2": {
+      "id": "planex_mzk-w300nh2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-planex_mzk-w300nh2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-planex_mzk-w300nh2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Planex MZK-WDPR": {
+      "id": "planex_mzk-wdpr",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-planex_mzk-wdpr-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Planex VR500": {
+      "id": "planex_vr500",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-planex_vr500-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Plat'Home OpenBlocks AX3 4 ports": {
+      "id": "plathome_openblocks-ax3-4",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-plathome_openblocks-ax3-4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa9-plathome_openblocks-ax3-4-squashfs-factory.img"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "Poray IP2202": {
+      "id": "poray_ip2202",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-poray_ip2202-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Poray M3": {
+      "id": "poray_m3",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-poray_m3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-poray_m3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Poray M4 4M": {
+      "id": "poray_m4-4m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-poray_m4-4m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-poray_m4-4m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Poray M4 8M": {
+      "id": "poray_m4-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-poray_m4-8m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-poray_m4-8m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Poray X5/X6": {
+      "id": "poray_x5",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-poray_x5-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-poray_x5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Poray X8": {
+      "id": "poray_x8",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-poray_x8-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt305x-poray_x8-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "PowerCloud Systems CAP324": {
+      "id": "pcs_cap324",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-pcs_cap324-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "PowerCloud Systems CR3000": {
+      "id": "pcs_cr3000",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-pcs_cr3000-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "PowerCloud Systems CR5000": {
+      "id": "pcs_cr5000",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-pcs_cr5000-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Prolink PWH2004": {
+      "id": "prolink_pwh2004",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-prolink_pwh2004-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Qihoo C301": {
+      "id": "qihoo_c301",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-qihoo_c301-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-qihoo_c301-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Qualcomm AP148 legacy": {
+      "id": "qcom_ipq8064-ap148-legacy",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-qcom_ipq8064-ap148-legacy-squashfs-nand-factory.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-qcom_ipq8064-ap148-legacy-squashfs-nand-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "Qualcomm AP148 standard": {
+      "id": "qcom_ipq8064-ap148",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-qcom_ipq8064-ap148-squashfs-nand-factory.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-qcom_ipq8064-ap148-squashfs-nand-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "Qualcomm AP161": {
+      "id": "qcom_ipq8064-ap161",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-qcom_ipq8064-ap161-squashfs-nand-factory.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-qcom_ipq8064-ap161-squashfs-nand-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "Qualcomm Atheros AP-DK01.1 C1": {
+      "id": "qcom_ap-dk01.1-c1",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-qcom_ap-dk01.1-c1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Qualcomm Atheros AP-DK04.1 C1": {
+      "id": "qcom_ap-dk04.1-c1",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-qcom_ap-dk04.1-c1-squashfs-nand-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-qcom_ap-dk04.1-c1-squashfs-nand-factory.ubi"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Qxwlan E2600AC C1": {
+      "id": "qxwlan_e2600ac-c1",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-qxwlan_e2600ac-c1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "Qxwlan E2600AC C2": {
+      "id": "qxwlan_e2600ac-c2",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-qxwlan_e2600ac-c2-squashfs-nand-factory.ubi"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-qxwlan_e2600ac-c2-squashfs-nand-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "RaidSonic ICY BOX IB-NAS62x0": {
+      "id": "raidsonic_ib-nas62x0",
+      "images": [
+        {
+          "name": "openwrt-kirkwood-raidsonic_ib-nas62x0-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-raidsonic_ib-nas62x0-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
+    },
+    "Raidsonic NAS IB-4220-B": {
+      "id": "raidsonic_ib-4220-b",
+      "images": [
+        {
+          "name": "openwrt-gemini-raidsonic_ib-4220-b-squashfs-factory.bin"
+        }
+      ],
+      "target": "gemini/"
+    },
+    "Rakwireless RAK633": {
+      "id": "rakwireless_rak633",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-rakwireless_rak633-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Ralink AP-RT3052-V22RW-2X2": {
+      "id": "ralink_v22rw-2x2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-ralink_v22rw-2x2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Ralink V11ST-FE": {
+      "id": "ralink_v11st-fe",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt288x-ralink_v11st-fe-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt288x"
+    },
+    "Ralink WR512-3GN 4M": {
+      "id": "unbranded_wr512-3gn-4m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-unbranded_wr512-3gn-4m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Ralink WR512-3GN 8M": {
+      "id": "unbranded_wr512-3gn-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-unbranded_wr512-3gn-8m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Raspberry Pi 2B-1.2/3B/3B+/3CM": {
+      "id": "rpi-3",
+      "images": [
+        {
+          "name": "openwrt-brcm2708-bcm2710-rpi-3-squashfs-factory.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2710-rpi-3-ext4-factory.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2710-rpi-3-squashfs-sysupgrade.img.gz"
+        }
+      ],
+      "target": "brcm2708/bcm2710"
+    },
+    "Raspberry Pi 2B/3B/3B+/3CM/4B": {
+      "id": "rpi-2",
+      "images": [
+        {
+          "name": "openwrt-brcm2708-bcm2709-rpi-2-ext4-factory.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2709-rpi-2-ext4-sysupgrade.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2709-rpi-2-squashfs-factory.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2709-rpi-2-squashfs-sysupgrade.img.gz"
+        }
+      ],
+      "target": "brcm2708/bcm2709"
+    },
+    "Raspberry Pi 4B": {
+      "id": "rpi-4",
+      "images": [
+        {
+          "name": "openwrt-brcm2708-bcm2711-rpi-4-squashfs-factory.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2711-rpi-4-squashfs-sysupgrade.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2711-rpi-4-ext4-factory.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2711-rpi-4-ext4-sysupgrade.img.gz"
+        }
+      ],
+      "target": "brcm2708/bcm2711"
+    },
+    "Raspberry Pi B/B+/CM/Zero/ZeroW": {
+      "id": "rpi",
+      "images": [
+        {
+          "name": "openwrt-brcm2708-bcm2708-rpi-ext4-factory.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2708-rpi-ext4-sysupgrade.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2708-rpi-squashfs-factory.img.gz"
+        },
+        {
+          "name": "openwrt-brcm2708-bcm2708-rpi-squashfs-sysupgrade.img.gz"
+        }
+      ],
+      "target": "brcm2708/bcm2708"
+    },
+    "Ravpower WD03": {
+      "id": "ravpower_wd03",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-ravpower_wd03-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Rosinson WR818": {
+      "id": "rosinson_wr818",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-rosinson_wr818-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "SFR Neufbox4 Foxconn": {
+      "id": "NEUFBOX4-FXC",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-NEUFBOX4-FXC-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "SFR Neufbox4 Sercomm": {
+      "id": "NEUFBOX4-SER",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-NEUFBOX4-SER-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "SFR Neufbox6": {
+      "id": "NEUFBOX6",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-NEUFBOX6-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "SKY SR102": {
+      "id": "SR102",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-SR102-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "STORYLiNK SAP-G3200U3": {
+      "id": "storylink_sap-g3200u3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-storylink_sap-g3200u3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Sagemcom F@st 2504N": {
+      "id": "FAST2504n",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-FAST2504n-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Sagemcom F@st 2704 V2": {
+      "id": "FAST2704V2",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-FAST2704V2-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Sagemcom F@st 2704N": {
+      "id": "FAST2704N",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-FAST2704N-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "SamKnows Whitebox 8": {
+      "id": "samknows_whitebox-v8",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-samknows_whitebox-v8-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Samsung CY-SWR1100": {
+      "id": "samsung_cy-swr1100",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-samsung_cy-swr1100-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt3883-samsung_cy-swr1100-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "Sanlinking Technologies D240": {
+      "id": "sanlinking_d240",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-sanlinking_d240-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
     },
     "Seagate FreeAgent Dockstar": {
       "id": "seagate_dockstar",
-      "target": "kirkwood",
       "images": [
-        "openwrt-kirkwood-seagate_dockstar-squashfs-factory.bin",
-        "openwrt-kirkwood-seagate_dockstar-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-kirkwood-seagate_dockstar-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-seagate_dockstar-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
     },
     "Seagate GoFlexHome": {
       "id": "seagate_goflexhome",
-      "target": "kirkwood",
       "images": [
-        "openwrt-kirkwood-seagate_goflexhome-squashfs-factory.bin",
-        "openwrt-kirkwood-seagate_goflexhome-squashfs-sysupgrade.bin"
-      ]
+        {
+          "name": "openwrt-kirkwood-seagate_goflexhome-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-seagate_goflexhome-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
+    },
+    "Seagate GoFlexNet": {
+      "id": "seagate_goflexnet",
+      "images": [
+        {
+          "name": "openwrt-kirkwood-seagate_goflexnet-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-seagate_goflexnet-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
+    },
+    "Sercomm AD1018 SPI flash mod": {
+      "id": "AD1018-SPI_flash",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-AD1018-SPI_flash-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Sercomm NA930": {
+      "id": "sercomm_na930",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-sercomm_na930-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Shuttle KD20": {
+      "id": "shuttle_kd20",
+      "images": [
+        {
+          "name": "openwrt-oxnas-ox820-shuttle_kd20-ubifs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-shuttle_kd20-ubifs-sysupgrade.tar"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-shuttle_kd20-squashfs-ubinized.bin"
+        },
+        {
+          "name": "openwrt-oxnas-ox820-shuttle_kd20-squashfs-sysupgrade.tar"
+        }
+      ],
+      "target": "oxnas/ox820"
+    },
+    "Siemens Gigaset sx76x": {
+      "id": "siemens_gigaset-sx76x",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-siemens_gigaset-sx76x-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Sinovoip Banana Pi M2+": {
+      "id": "sinovoip_bananapi-m2-plus",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-sinovoip_bananapi-m2-plus-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-sinovoip_bananapi-m2-plus-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Sitecom WL-351 v1": {
+      "id": "sitecom_wl-351",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-sitecom_wl-351-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Sitecom WLR-6000": {
+      "id": "sitecom_wlr-6000",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-sitecom_wlr-6000-squashfs-factory.dlf"
+        },
+        {
+          "name": "openwrt-ramips-rt3883-sitecom_wlr-6000-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "Sitecom WLR-7100 v1 002": {
+      "id": "sitecom_wlr-7100",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-sitecom_wlr-7100-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-sitecom_wlr-7100-squashfs-factory.dlf"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Skylab SKW92A": {
+      "id": "skylab_skw92a",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-skylab_skw92a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Skyline SL-R7205 Wireless 3G Router": {
+      "id": "skyline_sl-r7205",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-skyline_sl-r7205-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "SmartRG SR400ac": {
+      "id": "smartrg-sr400ac",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-smartrg-sr400ac-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "SolidRun Armada 8040 Community Board": {
+      "id": "marvell_macchiatobin",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa72-marvell_macchiatobin-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa72-marvell_macchiatobin-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa72"
+    },
+    "SolidRun ClearFog Base": {
+      "id": "solidrun_clearfog-base-a1",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-solidrun_clearfog-base-a1-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "SolidRun ClearFog Pro": {
+      "id": "solidrun_clearfog-pro-a1",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa9-solidrun_clearfog-pro-a1-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa9"
+    },
+    "SolidRun CuBox-i": {
+      "id": "cubox",
+      "images": [
+        {
+          "name": "openwrt-imx6-cubox-i-squashfs-combined.bin"
+        }
+      ],
+      "target": "imx6/"
+    },
+    "SolidRun MACCHIATObin": {
+      "id": "marvell_macchiatobin",
+      "images": [
+        {
+          "name": "openwrt-mvebu-cortexa72-marvell_macchiatobin-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-mvebu-cortexa72-marvell_macchiatobin-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "mvebu/cortexa72"
+    },
+    "Sophos RED 15w Rev.1": {
+      "id": "sophos_red-15w-rev1",
+      "images": [
+        {
+          "name": "openwrt-mpc85xx-generic-sophos_red-15w-rev1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "mpc85xx/generic"
+    },
+    "Sparklan WCR-150GN": {
+      "id": "sparklan_wcr-150gn",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-sparklan_wcr-150gn-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "StorLink SL93512r": {
+      "id": "storlink_sl93512r",
+      "images": [
+        {
+          "name": "openwrt-gemini-storlink_sl93512r-squashfs-factory.bin"
+        }
+      ],
+      "target": "gemini/"
+    },
+    "T-Com Speedport W 303V": {
+      "id": "SPW303V",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-SPW303V-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-brcm63xx-smp-SPW303V-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "TOTOLINK A7000R": {
+      "id": "totolink_a7000r",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-totolink_a7000r-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "TOTOLINK LR1200": {
+      "id": "totolink_lr1200",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-totolink_lr1200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-LINK Archer C5 v2": {
+      "id": "tplink-archer-c5-v2",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-tplink-archer-c5-v2-squashfs.bin"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "TP-LINK Archer C9 v1": {
+      "id": "tplink-archer-c9-v1",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-tplink-archer-c9-v1-squashfs.bin"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "TP-Link Archer A6 v2 (US/TW)": {
+      "id": "tplink_archer-c6-v2-us",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer A7 v5": {
+      "id": "tplink_archer-a7-v5",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-a7-v5-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-a7-v5-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C2 v1": {
+      "id": "tplink_archer-c2-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c2-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c2-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "TP-Link Archer C2 v3": {
+      "id": "tplink_archer-c2-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c2-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c2-v3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C20 v1": {
+      "id": "tplink_archer-c20-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c20-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c20-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "TP-Link Archer C20 v4": {
+      "id": "tplink_archer-c20-v4",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_archer-c20-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_archer-c20-v4-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link Archer C20 v5": {
+      "id": "tplink_archer-c20-v5",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_archer-c20-v5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link Archer C20i": {
+      "id": "tplink_archer-c20i",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c20i-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c20i-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "TP-Link Archer C25 v1": {
+      "id": "tplink_archer-c25-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c25-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c25-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C2600 v1": {
+      "id": "tplink_c2600",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-tplink_c2600-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-tplink_c2600-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "TP-Link Archer C5 v1": {
+      "id": "tplink_archer-c5-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c5-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c5-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C50 v1": {
+      "id": "tplink_archer-c50-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c50-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c50-v1-squashfs-factory-eu.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-c50-v1-squashfs-factory-us.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "TP-Link Archer C50 v3": {
+      "id": "tplink_archer-c50-v3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_archer-c50-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_archer-c50-v3-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link Archer C50 v4": {
+      "id": "tplink_archer-c50-v4",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_archer-c50-v4-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link Archer C58 v1": {
+      "id": "tplink_archer-c58-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c58-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c58-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C59 v1": {
+      "id": "tplink_archer-c59-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c59-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C59 v2": {
+      "id": "tplink_archer-c59-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c59-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c59-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C6 v2 (EU/RU/JP)": {
+      "id": "tplink_archer-c6-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c6-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c6-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C6 v2 (US)": {
+      "id": "tplink_archer-c6-v2-us",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C60 v1": {
+      "id": "tplink_archer-c60-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c60-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c60-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C60 v2": {
+      "id": "tplink_archer-c60-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c60-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c60-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C7 v1": {
+      "id": "tplink_archer-c7-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C7 v2": {
+      "id": "tplink_archer-c7-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v2-squashfs-factory-us.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v2-squashfs-factory-eu.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C7 v4": {
+      "id": "tplink_archer-c7-v4",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v4-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer C7 v5": {
+      "id": "tplink_archer-c7-v5",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v5-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-c7-v5-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer D50 v1": {
+      "id": "tplink_archer-d50-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_archer-d50-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link Archer MR200": {
+      "id": "tplink_archer-mr200",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-tplink_archer-mr200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "TP-Link Archer VR200 v1": {
+      "id": "tplink_vr200",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-tplink_vr200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "TP-Link Archer VR200v v1": {
+      "id": "tplink_vr200v",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-tplink_vr200v-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "TP-Link Archer VR2600v v1": {
+      "id": "tplink_vr2600v",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-tplink_vr2600v-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "TP-Link CPE210 v1": {
+      "id": "tplink_cpe210-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe210-v1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe210-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link CPE210 v2": {
+      "id": "tplink_cpe210-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe210-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe210-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link CPE210 v3": {
+      "id": "tplink_cpe210-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe210-v3-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe210-v3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link CPE220 v2": {
+      "id": "tplink_cpe220-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe220-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe220-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link CPE220 v3": {
+      "id": "tplink_cpe220-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe220-v3-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe220-v3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link CPE510 v1": {
+      "id": "tplink_cpe510-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe510-v1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe510-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link CPE510 v2": {
+      "id": "tplink_cpe510-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe510-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe510-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link CPE510 v3": {
+      "id": "tplink_cpe510-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe510-v3-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe510-v3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link CPE610 v1": {
+      "id": "tplink_cpe610-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe610-v1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_cpe610-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link RE200 v1": {
+      "id": "tplink_re200-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-tplink_re200-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-tplink_re200-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "TP-Link RE305 v1": {
+      "id": "tplink_re305-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_re305-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_re305-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link RE350 v1": {
+      "id": "tplink_re350-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-tplink_re350-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-tplink_re350-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "TP-Link RE350K v1": {
+      "id": "tplink_re350k-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_re350k-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_re350k-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link RE355 v1": {
+      "id": "tplink_re355-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_re355-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_re355-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link RE450 v1": {
+      "id": "tplink_re450-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_re450-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_re450-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link RE450 v2": {
+      "id": "tplink_re450-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_re450-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_re450-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link RE650 v1": {
+      "id": "tplink_re650-v1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-tplink_re650-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-tplink_re650-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "TP-Link TD-W8970 v1": {
+      "id": "tplink_tdw8970",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-tplink_tdw8970-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "TP-Link TD-W8980 v1": {
+      "id": "tplink_tdw8980",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-tplink_tdw8980-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "TP-Link TL-MR3020 v3": {
+      "id": "tplink_tl-mr3020-v3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-mr3020-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-mr3020-v3-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-MR3420 v5": {
+      "id": "tplink_tl-mr3420-v5",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-mr3420-v5-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-mr3420-v5-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-MR6400 v1": {
+      "id": "tplink_tl-mr6400-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-mr6400-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-mr6400-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WA801ND v5": {
+      "id": "tplink_tl-wa801nd-v5",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wa801nd-v5-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wa801nd-v5-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-WA850RE v1": {
+      "id": "tplink_tl-wa850re-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wa850re-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wa850re-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WA901ND v2": {
+      "id": "tplink_tl-wa901nd-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wa901nd-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wa901nd-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WDR3500 v1": {
+      "id": "tplink_tl-wdr3500-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr3500-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr3500-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WDR3600 v1": {
+      "id": "tplink_tl-wdr3600-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr3600-v1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr3600-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WDR4300 v1": {
+      "id": "tplink_tl-wdr4300-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr4300-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr4300-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WDR4300 v1 (IL)": {
+      "id": "tplink_tl-wdr4300-v1-il",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr4300-v1-il-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr4300-v1-il-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WDR4900 v1": {
+      "id": "tplink_tl-wdr4900-v1",
+      "images": [
+        {
+          "name": "openwrt-mpc85xx-generic-tplink_tl-wdr4900-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-mpc85xx-generic-tplink_tl-wdr4900-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "mpc85xx/generic"
+    },
+    "TP-Link TL-WDR4900 v2": {
+      "id": "tplink_tl-wdr4900-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr4900-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wdr4900-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR1043N v5": {
+      "id": "tplink_tl-wr1043n-v5",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043n-v5-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043n-v5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR1043N/ND v1": {
+      "id": "tplink_tl-wr1043nd-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043nd-v1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043nd-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR1043N/ND v2": {
+      "id": "tplink_tl-wr1043nd-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043nd-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043nd-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR1043N/ND v3": {
+      "id": "tplink_tl-wr1043nd-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043nd-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043nd-v3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR1043N/ND v4": {
+      "id": "tplink_tl-wr1043nd-v4",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043nd-v4-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1043nd-v4-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR1045ND v2": {
+      "id": "tplink_tl-wr1045nd-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1045nd-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr1045nd-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR2543N/ND v1": {
+      "id": "tplink_tl-wr2543-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr2543-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr2543-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR710N v1": {
+      "id": "tplink_tl-wr710n-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr710n-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr710n-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR740N v1/v2": {
+      "id": "tplink_tl-wr740n-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr740n-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr740n-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR740N v3": {
+      "id": "tplink_tl-wr740n-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr740n-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr740n-v3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR740N v4": {
+      "id": "tplink_tl-wr740n-v4",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr740n-v4-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr740n-v4-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR741N/ND v1/v2": {
+      "id": "tplink_tl-wr741-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr741-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr741-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR741N/ND v4": {
+      "id": "tplink_tl-wr741nd-v4",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr741nd-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr741nd-v4-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR743ND v1": {
+      "id": "tplink_tl-wr743nd-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr743nd-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr743nd-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR802N v4": {
+      "id": "tplink_tl-wr802n-v4",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr802n-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr802n-v4-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-WR810N v1": {
+      "id": "tplink_tl-wr810n-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr810n-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr810n-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR810N v2": {
+      "id": "tplink_tl-wr810n-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr810n-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr810n-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR840N v4": {
+      "id": "tplink_tl-wr840n-v4",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr840n-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr840n-v4-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-WR840N v5": {
+      "id": "tplink_tl-wr840n-v5",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr840n-v5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-WR841N v13": {
+      "id": "tplink_tl-wr841n-v13",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr841n-v13-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr841n-v13-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-WR841N v14": {
+      "id": "tplink_tl-wr841n-v14",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr841n-v14-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr841n-v14-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-WR841N/ND v10": {
+      "id": "tplink_tl-wr841-v10",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v10-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v10-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR841N/ND v11": {
+      "id": "tplink_tl-wr841-v11",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v11-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v11-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v11-squashfs-factory-us.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v11-squashfs-factory-eu.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR841N/ND v12": {
+      "id": "tplink_tl-wr841-v12",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v12-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v12-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v12-squashfs-factory-us.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v12-squashfs-factory-eu.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR841N/ND v5/v6": {
+      "id": "tplink_tl-wr841-v5",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v5-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR841N/ND v7": {
+      "id": "tplink_tl-wr841-v7",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v7-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v7-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR841N/ND v8": {
+      "id": "tplink_tl-wr841-v8",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v8-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v8-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR841N/ND v9": {
+      "id": "tplink_tl-wr841-v9",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v9-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr841-v9-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR842N v3": {
+      "id": "tplink_tl-wr842n-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr842n-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr842n-v3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR842N v5": {
+      "id": "tplink_tl-wr842n-v5",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr842n-v5-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr842n-v5-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-WR842N/ND v1": {
+      "id": "tplink_tl-wr842n-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr842n-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr842n-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR842N/ND v2": {
+      "id": "tplink_tl-wr842n-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr842n-v2-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr842n-v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR902AC v1": {
+      "id": "tplink_tl-wr902ac-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr902ac-v1-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_tl-wr902ac-v1-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link TL-WR902AC v3": {
+      "id": "tplink_tl-wr902ac-v3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr902ac-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-tplink_tl-wr902ac-v3-squashfs-tftp-recovery.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "TP-Link TL-WR940N v3": {
+      "id": "tplink_tl-wr940n-v3",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr940n-v3-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr940n-v3-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR940N v4": {
+      "id": "tplink_tl-wr940n-v4",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-factory-us.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-factory-eu.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr940n-v4-squashfs-factory-br.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR941N v2/v3": {
+      "id": "tplink_tl-wr941-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR941N v4": {
+      "id": "tplink_tl-wr941-v4",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941-v4-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR941N v7 (CN)": {
+      "id": "tplink_tl-wr941n-v7-cn",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941n-v7-cn-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941n-v7-cn-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR941ND v2/v3": {
+      "id": "tplink_tl-wr941-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR941ND v4": {
+      "id": "tplink_tl-wr941-v4",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941-v4-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941-v4-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link TL-WR941ND v6": {
+      "id": "tplink_tl-wr941nd-v6",
+      "images": [
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941nd-v6-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-tiny-tplink_tl-wr941nd-v6-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/tiny"
+    },
+    "TP-Link WBS210 v2": {
+      "id": "tplink_wbs210-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_wbs210-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_wbs210-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link WBS510 v1": {
+      "id": "tplink_wbs510-v1",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_wbs510-v1-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_wbs510-v1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TP-Link WBS510 v2": {
+      "id": "tplink_wbs510-v2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-tplink_wbs510-v2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-tplink_wbs510-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "TRENDnet TEW-638APB v2": {
+      "id": "trendnet_tew-638apb-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-trendnet_tew-638apb-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "TRENDnet TEW-691GR": {
+      "id": "trendnet_tew-691gr",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-trendnet_tew-691gr-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt3883-trendnet_tew-691gr-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "TRENDnet TEW-692GR": {
+      "id": "trendnet_tew-692gr",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt3883-trendnet_tew-692gr-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-rt3883-trendnet_tew-692gr-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt3883"
+    },
+    "TRENDnet TEW-714TRU": {
+      "id": "trendnet_tew-714tru",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-trendnet_tew-714tru-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Tama W06": {
+      "id": "tama_w06",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-tama_w06-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Tecom GW6000": {
+      "id": "GW6000",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-GW6000-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Tecom GW6200": {
+      "id": "GW6200",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-GW6200-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Telco Electronics X1": {
+      "id": "telco-electronics_x1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-telco-electronics_x1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Telekom Speedport W504V Typ A": {
+      "id": "arcadyan_arv8539pw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv8539pw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Telsey CPVA642-type (CPA-ZNTE60T)": {
+      "id": "CPA-ZNTE60T",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-CPA-ZNTE60T-squashfs-cfe.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "Teltonika RUT5XX": {
+      "id": "teltonika_rut5xx",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-teltonika_rut5xx-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Tenda 3G150B": {
+      "id": "tenda_3g150b",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-tenda_3g150b-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Tenda 3G300M": {
+      "id": "tenda_3g300m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-tenda_3g300m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Tenda AC9": {
+      "id": "tenda-ac9",
+      "images": [
+        {
+          "name": "openwrt-bcm53xx-generic-tenda-ac9-squashfs.trx"
+        }
+      ],
+      "target": "bcm53xx/generic"
+    },
+    "Tenda W150M": {
+      "id": "tenda_w150m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-tenda_w150m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Tenda W306R V2.0": {
+      "id": "tenda_w306r-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-tenda_w306r-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Texas Instruments AM335x BeagleBone Black": {
+      "id": "ti_am335x-bone-black",
+      "images": [
+        {
+          "name": "openwrt-omap-ti_am335x-bone-black-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-omap-ti_am335x-bone-black-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "omap/"
+    },
+    "Texas Instruments AM335x EVM": {
+      "id": "ti_am335x-evm",
+      "images": [
+        {
+          "name": "openwrt-omap-ti_am335x-evm-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-omap-ti_am335x-evm-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "omap/"
+    },
+    "Thunder Timecloud": {
+      "id": "thunder_timecloud",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-thunder_timecloud-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Toradex Apalis family": {
+      "id": "apalis",
+      "images": [
+        {
+          "name": "openwrt-imx6-apalis-squashfs.sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-imx6-apalis-squashfs.combined.bin"
+        }
+      ],
+      "target": "imx6/"
+    },
+    "Traverse LS1043 Boards": {
+      "id": "traverse-ls1043",
+      "images": [
+        {
+          "name": "openwrt-layerscape-armv8_64b-traverse-ls1043-ubifs-root"
+        },
+        {
+          "name": "openwrt-layerscape-armv8_64b-traverse-ls1043-ubifs-sysupgrade.bin"
+        }
+      ],
+      "target": "layerscape/armv8_64b"
+    },
+    "Trendnet TEW-823DRU v1.0R": {
+      "id": "trendnet_tew-823dru",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-trendnet_tew-823dru-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-trendnet_tew-823dru-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "UPVEL UR-326N4G": {
+      "id": "upvel_ur-326n4g",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-upvel_ur-326n4g-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "UPVEL UR-336UN": {
+      "id": "upvel_ur-336un",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-upvel_ur-336un-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "US Robotics USR5461": {
+      "id": "usrobotics-usr5461",
+      "images": [
+        {
+          "name": "openwrt-brcm47xx-legacy-usrobotics-usr5461-squashfs.bin"
+        }
+      ],
+      "target": "brcm47xx/legacy"
+    },
+    "Ubiquiti AirRouter XM": {
+      "id": "ubnt_airrouter",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_airrouter-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_airrouter-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti Bullet-M XM": {
+      "id": "ubnt_bullet-m",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_bullet-m-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_bullet-m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti Bullet-M XW": {
+      "id": "ubnt_bullet-m-xw",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_bullet-m-xw-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_bullet-m-xw-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti EdgeRouter": {
+      "id": "ubnt_edgerouter",
+      "images": [
+        {
+          "name": "openwrt-octeon-ubnt_edgerouter-squashfs-sysupgrade.tar"
+        }
+      ],
+      "target": "octeon/"
+    },
+    "Ubiquiti EdgeRouter Lite": {
+      "id": "ubnt_edgerouter-lite",
+      "images": [
+        {
+          "name": "openwrt-octeon-ubnt_edgerouter-lite-squashfs-sysupgrade.tar"
+        }
+      ],
+      "target": "octeon/"
+    },
+    "Ubiquiti EdgeRouter X": {
+      "id": "ubiquiti_edgerouterx",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-ubiquiti_edgerouterx-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Ubiquiti EdgeRouter X-SFP": {
+      "id": "ubiquiti_edgerouterx-sfp",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-ubiquiti_edgerouterx-sfp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Ubiquiti EdgeSwitch 5XP": {
+      "id": "ubnt_edgeswitch-5xp",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_edgeswitch-5xp-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_edgeswitch-5xp-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti EdgeSwitch 8XP": {
+      "id": "ubnt_edgeswitch-8xp",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_edgeswitch-8xp-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_edgeswitch-8xp-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti LiteAP ac LAP-120": {
+      "id": "ubnt_lap-120",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_lap-120-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_lap-120-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti LiteBeam AC Gen2": {
+      "id": "ubnt_litebeam-ac-gen2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_litebeam-ac-gen2-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_litebeam-ac-gen2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti NanoBeam AC": {
+      "id": "ubnt_nanobeam-ac",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanobeam-ac-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanobeam-ac-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti Nanostation AC": {
+      "id": "ubnt_nanostation-ac",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanostation-ac-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanostation-ac-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti Nanostation AC loco": {
+      "id": "ubnt_nanostation-ac-loco",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanostation-ac-loco-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanostation-ac-loco-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti Nanostation M XM": {
+      "id": "ubnt_nanostation-m",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanostation-m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanostation-m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti Nanostation M XW": {
+      "id": "ubnt_nanostation-m-xw",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanostation-m-xw-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_nanostation-m-xw-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti Rocket-M XM": {
+      "id": "ubnt_rocket-m",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_rocket-m-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_rocket-m-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti RouterStation": {
+      "id": "ubnt_routerstation",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_routerstation-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti RouterStation Pro": {
+      "id": "ubnt_routerstation-pro",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_routerstation-pro-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti UniFi": {
+      "id": "ubnt_unifi",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_unifi-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_unifi-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti UniFi AC-LR": {
+      "id": "ubnt_unifiac-lr",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_unifiac-lr-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti UniFi AC-Lite": {
+      "id": "ubnt_unifiac-lite",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_unifiac-lite-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti UniFi AC-Mesh": {
+      "id": "ubnt_unifiac-mesh",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_unifiac-mesh-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti UniFi AC-Mesh Pro": {
+      "id": "ubnt_unifiac-mesh-pro",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_unifiac-mesh-pro-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti UniFi AC-Pro": {
+      "id": "ubnt_unifiac-pro",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_unifiac-pro-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Ubiquiti XS2": {
+      "id": "ubnt2",
+      "images": [
+        {
+          "name": "openwrt-ath25-ubnt2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath25/"
+    },
+    "Ubiquiti XS2-8": {
+      "id": "ubnt2-pico2",
+      "images": [
+        {
+          "name": "openwrt-ath25-ubnt2-pico2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath25/"
+    },
+    "Ubiquiti XS5": {
+      "id": "ubnt5",
+      "images": [
+        {
+          "name": "openwrt-ath25-ubnt5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath25/"
+    },
+    "Ubiquiti airCube ISP": {
+      "id": "ubnt_acb-isp",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-ubnt_acb-isp-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-ubnt_acb-isp-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "UniElec U7621-06 16M": {
+      "id": "unielec_u7621-06-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-unielec_u7621-06-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "UniElec U7621-06 64M": {
+      "id": "unielec_u7621-06-64m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-unielec_u7621-06-64m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "UniElec U7623-02 eMMC/512MB RAM": {
+      "id": "unielec_u7623-02-emmc-512m",
+      "images": [
+        {
+          "name": "openwrt-mediatek-mt7623-unielec_u7623-02-emmc-512m-squashfs-sysupgrade-emmc.bin.gz"
+        }
+      ],
+      "target": "mediatek/mt7623"
+    },
+    "UniElec U7628-01 16M": {
+      "id": "unielec_u7628-01-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-unielec_u7628-01-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Unielec U4019 32M": {
+      "id": "unielec_u4019-32m",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-unielec_u4019-32m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "VoCore VoCore 16M": {
+      "id": "vocore_vocore-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-vocore_vocore-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "VoCore VoCore 8M": {
+      "id": "vocore_vocore-8m",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-vocore_vocore-8m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "VoCore VoCore2": {
+      "id": "vocore_vocore2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-vocore_vocore2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "VoCore VoCore2-Lite": {
+      "id": "vocore_vocore2-lite",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-vocore_vocore2-lite-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Vodafone Easybox 802": {
+      "id": "arcadyan_arv752dpw",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv752dpw-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Vodafone Easybox 803": {
+      "id": "arcadyan_arv752dpw22",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv752dpw22-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "Vonets VAR11N-300": {
+      "id": "vonets_var11n-300",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-vonets_var11n-300-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "WIZnet WizFi630A": {
+      "id": "wiznet_wizfi630a",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-wiznet_wizfi630a-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "WIZnet WizFi630S": {
+      "id": "wiznet_wizfi630s",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-wiznet_wizfi630s-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "WRTNode WRTNode": {
+      "id": "wrtnode_wrtnode",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-wrtnode_wrtnode-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "WRTnode WRTnode 2P": {
+      "id": "wrtnode_wrtnode2p",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-wrtnode_wrtnode2p-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "WRTnode WRTnode 2R": {
+      "id": "wrtnode_wrtnode2r",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-wrtnode_wrtnode2r-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Wansview NCS601W": {
+      "id": "wansview_ncs601w",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-wansview_ncs601w-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "Wavlink WL-WN570HA1": {
+      "id": "wavlink_wl-wn570ha1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-wavlink_wl-wn570ha1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Wavlink WL-WN575A3": {
+      "id": "wavlink_wl-wn575a3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-wavlink_wl-wn575a3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "WeVO 11AC NAS Router": {
+      "id": "wevo_11acnas",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-wevo_11acnas-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "WeVO W2914NS v2": {
+      "id": "wevo_w2914ns-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-wevo_w2914ns-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Western Digital My Book Live Series (Single + Duo)": {
+      "id": "wd_mybooklive",
+      "images": [
+        {
+          "name": "openwrt-apm821xx-sata-wd_mybooklive-ext4-factory.img.gz"
+        },
+        {
+          "name": "openwrt-apm821xx-sata-wd_mybooklive-ext4-sysupgrade.img.gz"
+        },
+        {
+          "name": "openwrt-apm821xx-sata-wd_mybooklive-squashfs-factory.img.gz"
+        },
+        {
+          "name": "openwrt-apm821xx-sata-wd_mybooklive-squashfs-sysupgrade.img.gz"
+        }
+      ],
+      "target": "apm821xx/sata"
+    },
+    "Western Digital My Net N750": {
+      "id": "wd_mynet-n750",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-wd_mynet-n750-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-wd_mynet-n750-squashfs-factory.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Western Digital My Net Wi-Fi Range Extender": {
+      "id": "wd_mynet-wifi-rangeextender",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-wd_mynet-wifi-rangeextender-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Widora Widora-NEO 16M": {
+      "id": "widora_neo-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-widora_neo-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Widora Widora-NEO 32M": {
+      "id": "widora_neo-32m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-widora_neo-32m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Winchannel WB2000": {
+      "id": "winchannel_wb2000",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-winchannel_wb2000-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Wippies BeWan iBox v1.0": {
+      "id": "arcadyan_arv4510pw",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-arcadyan_arv4510pw-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "XDX RN502J": {
+      "id": "unbranded_xdx-rn502j",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-unbranded_xdx-rn502j-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "XiaoYu XY-C5": {
+      "id": "xiaoyu_xy-c5",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-xiaoyu_xy-c5-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Xiaomi Mi Router 3 Pro": {
+      "id": "xiaomi_mir3p",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-xiaomi_mir3p-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-xiaomi_mir3p-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Xiaomi Mi Router 3G": {
+      "id": "xiaomi_mir3g",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-xiaomi_mir3g-squashfs-kernel1.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-xiaomi_mir3g-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7621-xiaomi_mir3g-squashfs-rootfs0.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Xiaomi Mi Router 3G v2": {
+      "id": "xiaomi_mir3g-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-xiaomi_mir3g-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Xiaomi Mi Router 4A 100M Edition": {
+      "id": "xiaomi_mir4a-100m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-xiaomi_mir4a-100m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Xiaomi Mi Router 4A Gigabit Edition": {
+      "id": "xiaomi_mir3g-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-xiaomi_mir3g-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Xiaomi Mi Router 4Q": {
+      "id": "xiaomi_mi-router-4q",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-xiaomi_mi-router-4q-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "Xiaomi MiWiFi Mini": {
+      "id": "xiaomi_miwifi-mini",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-xiaomi_miwifi-mini-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Xiaomi MiWiFi Nano": {
+      "id": "xiaomi_miwifi-nano",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-xiaomi_miwifi-nano-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Xilinx ZC702": {
+      "id": "xlnx_zynq-zc702",
+      "images": [
+        {
+          "name": "openwrt-zynq-xlnx_zynq-zc702-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "zynq/"
+    },
+    "Xunlong Orange Pi 2": {
+      "id": "xunlong_orangepi-2",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-2-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-2-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Xunlong Orange Pi One": {
+      "id": "xunlong_orangepi-one",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-one-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-one-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Xunlong Orange Pi PC": {
+      "id": "xunlong_orangepi-pc",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-pc-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-pc-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Xunlong Orange Pi PC 2": {
+      "id": "xunlong_orangepi-pc2",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa53-xunlong_orangepi-pc2-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa53-xunlong_orangepi-pc2-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa53"
+    },
+    "Xunlong Orange Pi PC Plus": {
+      "id": "xunlong_orangepi-pc-plus",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-pc-plus-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-pc-plus-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Xunlong Orange Pi Plus": {
+      "id": "xunlong_orangepi-plus",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-plus-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-plus-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Xunlong Orange Pi R1": {
+      "id": "xunlong_orangepi-r1",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-r1-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-r1-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Xunlong Orange Pi Zero": {
+      "id": "xunlong_orangepi-zero",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-zero-squashfs-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa7-xunlong_orangepi-zero-ext4-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa7"
+    },
+    "Xunlong Orange Pi Zero Plus": {
+      "id": "xunlong_orangepi-zero-plus",
+      "images": [
+        {
+          "name": "openwrt-sunxi-cortexa53-xunlong_orangepi-zero-plus-ext4-sdcard.img.gz"
+        },
+        {
+          "name": "openwrt-sunxi-cortexa53-xunlong_orangepi-zero-plus-squashfs-sdcard.img.gz"
+        }
+      ],
+      "target": "sunxi/cortexa53"
+    },
+    "YOUKU YK1": {
+      "id": "youku_yk1",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-youku_yk1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "YUKAI Engineering BOCCO": {
+      "id": "yukai_bocco",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-yukai_bocco-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "YouHua WR1200JS": {
+      "id": "youhua_wr1200js",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-youhua_wr1200js-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Youku YK-L2": {
+      "id": "youku_yk-l2",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-youku_yk-l2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "YunCore A770": {
+      "id": "yuncore_a770",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-yuncore_a770-squashfs-tftp.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-yuncore_a770-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "YunCore A782": {
+      "id": "yuncore_a782",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-yuncore_a782-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-yuncore_a782-squashfs-tftp.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "YunCore XD4200": {
+      "id": "yuncore_xd4200",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-yuncore_xd4200-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-yuncore_xd4200-squashfs-tftp.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "ZBT WD323": {
+      "id": "zbtlink_zbt-wd323",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-zbtlink_zbt-wd323-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "ZIO FREEZIO": {
+      "id": "zio_freezio",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-zio_freezio-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ZTE H201L": {
+      "id": "zte_h201l",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-zte_h201l-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "ZTE Q7": {
+      "id": "zte_q7",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zte_q7-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-APE522II": {
+      "id": "zbtlink_zbt-ape522ii",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-ape522ii-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-CPE102": {
+      "id": "zbtlink_zbt-cpe102",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-cpe102-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-WA05": {
+      "id": "zbtlink_zbt-wa05",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-wa05-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-WE1026-5G 16M": {
+      "id": "zbtlink_zbt-we1026-5g-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-we1026-5g-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-WE1026-H 32M": {
+      "id": "zbtlink_zbt-we1026-h-32m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-we1026-h-32m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-WE1226": {
+      "id": "zbtlink_zbt-we1226",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-zbtlink_zbt-we1226-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "Zbtlink ZBT-WE1326": {
+      "id": "zbtlink_zbt-we1326",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-zbtlink_zbt-we1326-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Zbtlink ZBT-WE2026": {
+      "id": "zbtlink_zbt-we2026",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-we2026-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-WE3526": {
+      "id": "zbtlink_zbt-we3526",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-zbtlink_zbt-we3526-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Zbtlink ZBT-WE826 16M": {
+      "id": "zbtlink_zbt-we826-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-we826-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-WE826 32M": {
+      "id": "zbtlink_zbt-we826-32m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-we826-32m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-WE826-E": {
+      "id": "zbtlink_zbt-we826-e",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-we826-e-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zbtlink ZBT-WG2626": {
+      "id": "zbtlink_zbt-wg2626",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-zbtlink_zbt-wg2626-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Zbtlink ZBT-WG3526 16M": {
+      "id": "zbtlink_zbt-wg3526-16m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-zbtlink_zbt-wg3526-16m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Zbtlink ZBT-WG3526 32M": {
+      "id": "zbtlink_zbt-wg3526-32m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-zbtlink_zbt-wg3526-32m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "Zbtlink ZBT-WR8305RT": {
+      "id": "zbtlink_zbt-wr8305rt",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zbtlink_zbt-wr8305rt-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "Zorlik ZL5900V2": {
+      "id": "zorlik_zl5900v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-zorlik_zl5900v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "ZyXEL Keenetic": {
+      "id": "zyxel_keenetic",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-zyxel_keenetic-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "ZyXEL Keenetic Extra II": {
+      "id": "zyxel_keenetic-extra-ii",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-zyxel_keenetic-extra-ii-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt76x8-zyxel_keenetic-extra-ii-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "ZyXEL Keenetic Omni": {
+      "id": "zyxel_keenetic-omni",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zyxel_keenetic-omni-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-zyxel_keenetic-omni-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "ZyXEL Keenetic Omni II": {
+      "id": "zyxel_keenetic-omni-ii",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zyxel_keenetic-omni-ii-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-zyxel_keenetic-omni-ii-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "ZyXEL Keenetic Start": {
+      "id": "zyxel_keenetic-start",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-zyxel_keenetic-start-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "ZyXEL Keenetic Viva": {
+      "id": "zyxel_keenetic-viva",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-zyxel_keenetic-viva-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ramips-mt7620-zyxel_keenetic-viva-squashfs-factory.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "ZyXEL NBG-419N": {
+      "id": "zyxel_nbg-419n",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-zyxel_nbg-419n-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "ZyXEL NBG-419N v2": {
+      "id": "zyxel_nbg-419n-v2",
+      "images": [
+        {
+          "name": "openwrt-ramips-rt305x-zyxel_nbg-419n-v2-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/rt305x"
+    },
+    "ZyXEL NBG6617": {
+      "id": "zyxel_nbg6617",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-zyxel_nbg6617-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq40xx-generic-zyxel_nbg6617-squashfs-factory.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "ZyXEL NBG6716": {
+      "id": "zyxel_nbg6716",
+      "images": [
+        {
+          "name": "openwrt-ath79-nand-zyxel_nbg6716-squashfs-sysupgrade.tar"
+        },
+        {
+          "name": "openwrt-ath79-nand-zyxel_nbg6716-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-ath79-nand-zyxel_nbg6716-squashfs-sysupgrade-4M-Kernel.bin"
+        }
+      ],
+      "target": "ath79/nand"
+    },
+    "ZyXEL NBG6817": {
+      "id": "zyxel_nbg6817",
+      "images": [
+        {
+          "name": "openwrt-ipq806x-generic-zyxel_nbg6817-squashfs-sysupgrade.bin"
+        },
+        {
+          "name": "openwrt-ipq806x-generic-zyxel_nbg6817-squashfs-factory.bin"
+        }
+      ],
+      "target": "ipq806x/generic"
+    },
+    "ZyXEL NSA310b": {
+      "id": "zyxel_nsa310b",
+      "images": [
+        {
+          "name": "openwrt-kirkwood-zyxel_nsa310b-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-zyxel_nsa310b-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
+    },
+    "ZyXEL NSA325 v1/v2": {
+      "id": "zyxel_nsa325",
+      "images": [
+        {
+          "name": "openwrt-kirkwood-zyxel_nsa325-squashfs-factory.bin"
+        },
+        {
+          "name": "openwrt-kirkwood-zyxel_nsa325-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "kirkwood/"
+    },
+    "ZyXEL P-2601HN F1/F3": {
+      "id": "zyxel_p-2601hn",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xway-zyxel_p-2601hn-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xway"
+    },
+    "ZyXEL P-2812HNU F1": {
+      "id": "zyxel_p-2812hnu-f1",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-zyxel_p-2812hnu-f1-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "ZyXEL P-2812HNU F3": {
+      "id": "zyxel_p-2812hnu-f3",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-zyxel_p-2812hnu-f3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "ZyXEL P870HW-51a v2": {
+      "id": "P870HW-51a_v2",
+      "images": [
+        {
+          "name": "openwrt-brcm63xx-smp-P870HW-51a_v2-squashfs-factory.bin"
+        }
+      ],
+      "target": "brcm63xx/smp"
+    },
+    "ZyXEL WRE6606": {
+      "id": "zyxel_wre6606",
+      "images": [
+        {
+          "name": "openwrt-ipq40xx-generic-zyxel_wre6606-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ipq40xx/generic"
+    },
+    "devolo WiFi pro 1200e": {
+      "id": "devolo_dvl1200e",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-devolo_dvl1200e-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "devolo WiFi pro 1200i": {
+      "id": "devolo_dvl1200i",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-devolo_dvl1200i-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "devolo WiFi pro 1750c": {
+      "id": "devolo_dvl1750c",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-devolo_dvl1750c-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "devolo WiFi pro 1750e": {
+      "id": "devolo_dvl1750e",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-devolo_dvl1750e-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "devolo WiFi pro 1750i": {
+      "id": "devolo_dvl1750i",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-devolo_dvl1750i-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "devolo WiFi pro 1750x": {
+      "id": "devolo_dvl1750x",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-devolo_dvl1750x-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "eTactica EG200": {
+      "id": "etactica_eg200",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-etactica_eg200-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "egnite Ethernut 5": {
+      "id": "ethernut5",
+      "images": [
+        {
+          "name": "openwrt-at91-sam9x-ethernut5-ubifs-root.ubi"
+        },
+        {
+          "name": "openwrt-at91-sam9x-ethernut5-squashfs-root.ubi"
+        }
+      ],
+      "target": "at91/sam9x"
+    },
+    "ipTIME A104ns": {
+      "id": "iptime_a104ns",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7620-iptime_a104ns-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7620"
+    },
+    "ipTIME A3": {
+      "id": "iptime_a3",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-iptime_a3-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "ipTIME A604M": {
+      "id": "iptime_a604m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt76x8-iptime_a604m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt76x8"
+    },
+    "ipTIME A6ns-M": {
+      "id": "iptime_a6ns-m",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-iptime_a6ns-m-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "ipTIME A8004T": {
+      "id": "iptime_a8004t",
+      "images": [
+        {
+          "name": "openwrt-ramips-mt7621-iptime_a8004t-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "ramips/mt7621"
+    },
+    "jjPlus JA76PF2": {
+      "id": "jjplus_ja76pf2",
+      "images": [
+        {
+          "name": "openwrt-ath79-generic-jjplus_ja76pf2-squashfs-kernel.bin"
+        },
+        {
+          "name": "openwrt-ath79-generic-jjplus_ja76pf2-squashfs-rootfs.bin"
+        }
+      ],
+      "target": "ath79/generic"
+    },
+    "o2 Box 6431 BRN": {
+      "id": "arcadyan_vgv7510kw22-brn",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vgv7510kw22-brn-squashfs-factory.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
+    },
+    "o2 Box 6431 NOR": {
+      "id": "arcadyan_vgv7510kw22-nor",
+      "images": [
+        {
+          "name": "openwrt-lantiq-xrx200-arcadyan_vgv7510kw22-nor-squashfs-sysupgrade.bin"
+        }
+      ],
+      "target": "lantiq/xrx200"
     }
-  }
+  },
+  "url": "https://downloads.openwrt.org/snapshots/targets/{target}",
+  "version_commit": "r12145-4716c843d6"
 }


### PR DESCRIPTION
again, make JSON files more like upstream:

* images: use dict instead of simple file. This allows adding
information like checksums or types. Again, I dealt so much with
heuristics withn OpenWrt build system that I avoid it as much as
possible. From my side I'd remove fragments like `findCommonPrefix` and
just rely on upstream info.
* commit: replace with `version_commit` (as there is also
`version_number`
* link: replace with `url` as *link* referes to something clickable in
the browser while url is more generic, including machine reads
* activate sort_keys in collect.py, this creates reproducible json files
and surely makes some JSON parser happy
* %foobar: instead of using `%` I changed the replacement to mustache[0]
which is also usable via Pythons `format()` function and easier to read.
Say a string like %target-info/foobar could mean a variable `target` or
`target-info`, using {target}-info/foobar makes things easier
* %file: remove this entirely and just append whatever desired file at
the end. Is there any case where the downloaded file is not at the end?

all these changes where done to be compatile with the *asu*, meaning a
image builder backend that creates images with specificed packages on
demand. Example code is added within the top of index.js. The server
takes `version`, `profile` and `packages` as arguments and returns
within a few seconds a freshly build firmware, which is automatically
shown in the frontend.

[0]: mustache.github.io/

Signed-off-by: Paul Spooren <mail@aparcar.org>