### PR TITLE
fixup: rename version_commit to version_code

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function build_asa_request() {
           var download_url = config.asu_url + '/store/' + mobj.bin_dir;
           updateImages(
             mobj.version_number,
-            mobj.version_commit,
+            mobj.version_code,
             mobj.build_at,
             get_model_titles(mobj.titles),
             download_url, mobj, true


### PR DESCRIPTION
Since OpenWrt upstream 07449f692c the variable is called `version_code`
instead of `version_commit` as it is really not only a commit but a
combination of *number of commits* and commit hash.

Signed-off-by: Paul Spooren <mail@aparcar.org>