### PR TITLE
asu: send target to ASU server

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ function build_asa_request() {
   showStatus('<span class="tr-request-image"></span>');
 
   var request_data = {
+    'target': current_model.target,
     'profile': current_model.id,
     'packages': split($('packages').value),
     'version': $('versions').value


### PR DESCRIPTION
The updated API requires the target as the 'profiles' are not unique
(e.g. for x86 images).

Signed-off-by: Paul Spooren <mail@aparcar.org>